### PR TITLE
Feature multi cycle

### DIFF
--- a/long-runs/Input_data.md
+++ b/long-runs/Input_data.md
@@ -28,10 +28,47 @@ The contents of each entry are detailed below.
     - Order: `pos[0]` $\rightarrow \, x$, &ensp; `pos[1]` $\rightarrow \, y$
 - SEDs: it is a `numpy` ndarray containing the SED asociated to each observed star. For each star, the SED is composed by a set of `n_bins` frequency values, a set of `n_bins` SED values and a set of `n_bins` bin weights proportional to the relative size of each bin with respect to the whole SED bandwidth.
     - Shape: `(n_stars, n_bins, 3)`.
-    - Order: `SED[0]` $\rightarrow \, \lambda$,&ensp; `SED[1]` $\rightarrow \, \text{SED}(\lambda)$,&ensp; `SED[2]` $\rightarrow \, \frac{\Delta_{\text{bin}}}{B}$.
+    - Order: `SED[i,:,0]` $\rightarrow \, \lambda$,&ensp; `SED[i,:,1]` $\rightarrow \, \text{SED}(\lambda)$,&ensp; `SED[i,:,2]` $\rightarrow \, \frac{\Delta_{\text{bin}}}{B}$.
 - Zernike_coef: it is a `numpy` ndarray containing the ground truth `n_zernike_gt` coefficients of each observed PSF wavefront error.
     - Shape: `(n_stars, n_zernike_gt, 1)`.
 - C_poly: it is a `numpy` ndarray containing the ground truth coefficients of the spatial variation polynomials asociated to each Zernike order. Each polynomial has a degree `d_max` and thus the number of coefficients is $n_{\text{max}} = (d_{\text{max}}+1)(d_{\text{max}}+2)/2$.
     - Shape: `(n_zernikes_gt, n_max)`.
 - Parameters: it is a python dictionary containing information about the data generation model parameters.
     - Keys: `['d_max', 'max_order', 'x_lims', 'y_lims', 'grid_points', 'n_bins', 'max_wfe_rms', 'oversampling_rate', 'output_Q', 'output_dim', 'LP_filter_length', 'pupil_diameter', 'euclid_obsc', 'n_stars']`.
+
+
+## Tensorflow inputs and outputs
+
+From each dataset, the inputs and outputs for the model will be generated. The inputs of the model, $X$, are the star positions and the SEDs. The outputs of the model, $Y$, are the noisy stars which will be constrasted with the model's predictions $\hat{Y}$ to compute the loss $\mathcal{L}(Y, \hat{Y})$.
+
+### Inputs
+As mentioned before the input will contain two tensors, the first one containing the $(x,y)$ FOV positions and the second one containing the SED for each observation.
+
+```
+inputs = [tf_pos, tf_packed_SED_data]
+```
+
+- `tf_pos` is a tensor of shape `([n_stars,2])`. The order of the $(x,y)$ positions are the same as before. 
+
+- `tf_packed_SED_data` is a tensor of shape `([n_stars,n_bins,3])`. For each observation $i$ this tensor  contains three `n_bins`-point SED features. The first one contains each integer `feasible_N` needed for the upscaling of the wavefront error in order to compute the PSF at each `feasible_wv` (listed in the second position). Finaly in the third position the SED values are listed for each `feasible_wv`. 
+    - Notes 
+        - The `feasible_N` asociated to each `feasible_wv` is calculated using the [`SimPSFToolkit.feasible_N()`](https://github.com/tobias-liaudat/wf-psf/blob/main/wf_psf/SimPSFToolkit.py#L636) method. 
+        - The packed SED date is generated with the [generate_packed_elems()](https://github.com/tobias-liaudat/wf-psf/blob/main/wf_psf/utils.py#L44) method of the `wf_utils` class detailed in the `utils.py` file.
+        - The packed SED data must be converted to tensor to be an input of the model (a column permutation also takes place):
+        ```
+        tf_packed_SED_data = tf.convert_to_tensor(packed_SED_data, dtype=tf.float32)
+        tf_packed_SED_data = tf.transpose(tf_packed_SED_data, perm=[0, 2, 1])
+        ```
+        
+### Outputs
+The output of the WaveDiff model contains the noisy low-resolution star observations. 
+```
+outputs = [tf_noisy_train_stars]
+```
+
+-  `tf_noisy_train_stars` is a tensor of shape `([n_stars, output_dim, output_dim])` containing the noisy observation of each star. 
+    - Notes
+        - The train stars must be converted to tensor in order to be used by the model. 
+        ```
+        tf_noisy_train_stars = tf.convert_to_tensor(train_dataset['noisy_stars'], dtype=tf.float32)
+        ```

--- a/long-runs/Input_data.md
+++ b/long-runs/Input_data.md
@@ -51,7 +51,13 @@ inputs = [tf_pos, tf_packed_SED_data]
 - `tf_pos` is a tensor of shape `([n_stars,2])`. The order of the $(x,y)$ positions are the same as before. 
 
 - `tf_packed_SED_data` is a tensor of shape `([n_stars,n_bins,3])`. For each observation $i$ this tensor  contains three `n_bins`-point SED features. The first one contains each integer `feasible_N` needed for the upscaling of the wavefront error in order to compute the PSF at each `feasible_wv` (listed in the second position). Finaly in the third position the SED values are listed for each `feasible_wv`. 
-    - Notes 
+    - Notes
+        - The second dimention of the packed SED data can change its lenght if SED interpolation is performed. The interpolated SED will then have the following number of samples:
+
+            $n_{\text{bins\_interp}} = n_{\text{bins}} \times (\texttt{interp\_pts\_per\_bin} + 1) \; \pm \; 1$,
+
+            if extrapolation is performed, a point is added to the SED, thus it corresponts to the $+1$ case. If exptrapolation is not performed the $-1$ case is considered.  
+
         - The `feasible_N` asociated to each `feasible_wv` is calculated using the [`SimPSFToolkit.feasible_N()`](https://github.com/tobias-liaudat/wf-psf/blob/main/wf_psf/SimPSFToolkit.py#L636) method. 
         - The packed SED date is generated with the [generate_packed_elems()](https://github.com/tobias-liaudat/wf-psf/blob/main/wf_psf/utils.py#L44) method of the `wf_utils` class detailed in the `utils.py` file.
         - The packed SED data must be converted to tensor to be an input of the model (a column permutation also takes place):

--- a/long-runs/Input_data.md
+++ b/long-runs/Input_data.md
@@ -1,0 +1,37 @@
+# Inputs of the WaveDiff model
+
+For the model to be trained a dataset is needed. The train and test datasets for the WaveDiff model are detailed below. 
+
+## Input datasets
+This model uses two datasets, one for optimising the model and another for testing the model. Both datasets are organised as python dictionaries.
+
+### Dataset keys
+
+```
+train_dataset.keys() --> ['stars', 'noisy_stars', 'super_res_stars', 'positions', 'SEDs', 'zernike_coef', 'C_poly', 'parameters']
+
+test_dataset.keys() --> ['stars', 'super_res_stars', 'positions', 'SEDs', 'zernike_coef', 'C_poly', 'parameters']
+```
+
+The contents of each entry are detailed below.
+
+## Composition of the datasets
+
+- Stars: it is a `numpy` ndarray containing the low resolution observations of each star. 
+    - Shape: `(n_stars, output_dim, output_dim)`.
+- Noisy stars: it is a `numpy` ndarray containing noisy version of the low resolution observations of each star.
+    - Shape: `(n_stars, output_dim, output_dim)`.
+- Super resolved stars: it is a `numpy` ndarray containing the high resolution observations of each star.
+    - Shape: `(n_stars, super_out_res, super_out_res)`.
+- Positions: it is a `numpy` ndarray containing the $(x,y)$ FOV position of each observation.
+    - Shape: `(n_stars, 2)`.
+    - Order: `pos[0]` $\rightarrow \, x$, &ensp; `pos[1]` $\rightarrow \, y$
+- SEDs: it is a `numpy` ndarray containing the SED asociated to each observed star. For each star, the SED is composed by a set of `n_bins` frequency values, a set of `n_bins` SED values and a set of `n_bins` bin weights proportional to the relative size of each bin with respect to the whole SED bandwidth.
+    - Shape: `(n_stars, n_bins, 3)`.
+    - Order: `SED[0]` $\rightarrow \, \lambda$,&ensp; `SED[1]` $\rightarrow \, \text{SED}(\lambda)$,&ensp; `SED[2]` $\rightarrow \, \frac{\Delta_{\text{bin}}}{B}$.
+- Zernike_coef: it is a `numpy` ndarray containing the ground truth `n_zernike_gt` coefficients of each observed PSF wavefront error.
+    - Shape: `(n_stars, n_zernike_gt, 1)`.
+- C_poly: it is a `numpy` ndarray containing the ground truth coefficients of the spatial variation polynomials asociated to each Zernike order. Each polynomial has a degree `d_max` and thus the number of coefficients is $n_{\text{max}} = (d_{\text{max}}+1)(d_{\text{max}}+2)/2$.
+    - Shape: `(n_zernikes_gt, n_max)`.
+- Parameters: it is a python dictionary containing information about the data generation model parameters.
+    - Keys: `['d_max', 'max_order', 'x_lims', 'y_lims', 'grid_points', 'n_bins', 'max_wfe_rms', 'oversampling_rate', 'output_Q', 'output_dim', 'LP_filter_length', 'pupil_diameter', 'euclid_obsc', 'n_stars']`.

--- a/long-runs/README.md
+++ b/long-runs/README.md
@@ -1,0 +1,238 @@
+# Use of the WaveDiff model
+
+The model should be installed as a python package as detailed in the main [README](https://github.com/tobias-liaudat/wf-psf) file. The `wf-psf` package includes functions to train, evaluate and plot the results of the model. In this file we detail how to make use of this functions.
+
+## Auxiliary functions
+
+The package has two main functions to perform test with the WaveDiff model. One function for running the model's optimisation process and one function for performing evaluation and saving the results. There is a third function that generates some plots when the evaluation is finished. This functions can be found in the [`script_utils.py`](https://github.com/tobias-liaudat/wf-psf/blob/main/wf_psf/script_utils.py) file. 
+
+- `train_model(**args)` : trains the PSF model.
+- `evaluate_model(**args)` : evaluate the trained PSF model. 
+- `plot_metrics(**args)`: Plot model results.
+
+The arguments of these functions are detailed below. 
+
+## Training script
+For runing the previous functions one can use the [`train_eval_plot_script_click.py`](https://github.com/tobias-liaudat/wf-psf/blob/main/long-runs/train_eval_plot_script_click.py) script. This script calls each of the above functions and serves as an interface to collect the `**args` optios from command line arguments using the [`click`](https://click.palletsprojects.com/en/8.1.x/) package. 
+
+To run the script one should input the desired parameters as command line arguments as in the following example:
+
+```
+./train_eval_plot_script_click.py \
+    --train_opt True \
+    --eval_opt True \
+    --plot_opt True \
+    --model poly \
+    --id_name your_id \
+    --suffix_id_name _1k_stars --suffix_id_name _2k_stars \
+    --id_name your_id_1k_stars --id_name your_id_2k_stars \
+    --star_numbers 1000 --stars_numbers 2000 \
+    --base_path your/base/path/wf-outputs/ \
+    ...
+    --pupil_diameter 256 \
+    --n_epochs_param_multi_cycle "15 15" \
+    --n_epochs_non_param_multi_cycle "100 50" \
+    --l_rate_non_param_multi_cycle "0.1 0.06" \
+    --l_rate_param_multi_cycle "0.01 0.004" \
+    ...
+```
+
+The options that remain unset will take the default values defined in the [`train_eval_plot_script_click.py`](https://github.com/tobias-liaudat/wf-psf/blob/main/long-runs/train_eval_plot_script_click.py) script.
+
+# Script options 
+Here we detail every option or argument used in the WaveDiff model auxiliary script. 
+
+## Script options
+
+- `--train_opt`, default=True, type: bool
+	- Train the model.
+
+- `--eval_opt`, default=True, type: bool
+	- Evaluate the model.
+
+- `--plot_opt`, default=True, type: bool
+	- Plot the model results
+## Training options
+### Model definition
+
+- `--model`, default="poly", type: str
+	- Model type. Options are: 'mccd', 'graph', 'poly, 'param', 'poly_physical'.
+
+- `--id_name`, default="-coherent_euclid_200stars", type: str
+    - Model saving id.
+### Saving paths
+
+- `--base_path`, default="/gpfswork/rech/ynx/ulx23va/wf-outputs/", type: str
+	- Base path for saving files.
+
+- `--log_folder`, default="log-files/", type: str
+	- Folder name to save log files.
+
+- `--model_folder`, default="chkp/", type: str
+	- Folder name to save trained models.
+
+- `--optim_hist_folder`, default="optim-hist/", type: str
+	- Folder name to save optimisation history files.
+
+- `--chkp_save_path`, default="/gpfsscratch/rech/ynx/ulx23va/wf-outputs/chkp/", type: str
+	- Path to save model checkpoints during training.
+
+- `--plots_folder`, default="plots/", type: str
+	- Folder name to save the generated plots.
+### Input dataset paths
+
+- `--dataset_folder`, default="/gpfswork/rech/ynx/ulx23va/repo/wf-psf/data/coherent_euclid_dataset/", type: str
+	- Folder path of datasets.
+
+- `--train_dataset_file`, default="train_Euclid_res_200_TrainStars_id_001.npy", type: str
+	- Train dataset file name.
+
+- `--test_dataset_file`, default="test_Euclid_res_id_001.npy", type: str
+	- Test dataset file name.
+## Model parameters
+
+- `--n_zernikes`, default=15, type: int
+	- Zernike polynomial modes to use on the parametric part.
+
+- `--pupil_diameter`, default=256, type: int
+	- Dimension of the OPD/Wavefront space.
+
+- `--n_bins_lda`, default=20, type: int
+	- Number of wavelength bins to use to reconstruct polychromatic objects.
+
+- `--output_q`, default=3., type: float
+	- Downsampling rate to match the specified telescope's sampling from the oversampling rate used in the model.
+
+- `--oversampling_rate`, default=3., type: float
+	- Oversampling rate used for the OPD/WFE PSF model.
+
+- `--output_dim`, default=32, type: int
+	- Dimension of the pixel PSF postage stamp.
+
+- `--d_max`, default=2, type: int
+	- Max polynomial degree of the parametric part.
+
+- `--d_max_nonparam`, default=3, type: int
+	- Max polynomial degree of the non-parametric part.
+
+- `--x_lims`
+nargs=2,, default=[0, 1e3], type: float
+	- Limits of the PSF field coordinates for the x axis.
+
+- `--y_lims`
+nargs=2,, default=[0, 1e3], type: float
+	- Limits of the PSF field coordinates for the y axis.
+
+- `--graph_features`, default=10, type: int
+	- Number of graph-constrained features of the non-parametric part.
+
+- `--l1_rate`, default=1e-8, type: float
+	- L1 regularisation parameter for the non-parametric part.
+
+- `--use_sample_weights`, default=False, type: bool
+	- Boolean to define if we use sample weights based on the noise standard deviation estimation.
+
+- `--interpolation_type`, default="none", type: str
+	- The interpolation type for the physical poly model. Options are: 'none', 'all', 'top_K', 'independent_Zk'.
+## Training parameters
+
+- `--batch_size`, default=32, type: int
+	- Batch size used for the trainingin the stochastic gradient descend type of algorithm.
+### Old multicycle parameters for backwards compatibility. 
+
+- `--l_rate_param`
+nargs=2,, default=None, type: float
+	- Learning rates for the parametric parts.
+
+- `--l_rate_non_param`
+nargs=2,, default=None, type: float
+	- Learning rates for the non-parametric parts.
+
+- `--n_epochs_param`
+nargs=2,, default=None, type: int
+	- Number of training epochs of the parametric parts.
+
+- `--n_epochs_non_param`
+nargs=2,, default=None, type: int
+	- Number of training epochs of the non-parametric parts.
+### New multicycle parameters
+
+- `--l_rate_param_multi_cycle`, default="1e-2 1e-2", type: str
+	- Learning rates for the parametric parts. It should be a strign where numeric values are separated by spaces.
+
+- `--l_rate_non_param_multi_cycle`, default="1e-1 1e-1", type: str
+	- Learning rates for the non-parametric parts. It should be a strign where numeric values are separated by spaces.
+
+- `--n_epochs_param_multi_cycle`, default="20 20", type: str
+	- Number of training epochs of the parametric parts. It should be a strign where numeric values are separated by spaces.
+
+- `--n_epochs_non_param_multi_cycle`, default="100 120", type: str
+	- Number of training epochs of the non-parametric parts. It should be a strign where numeric values are separated by spaces.
+
+- `--save_all_cycles`, default=False, type: bool
+	- Make checkpoint at every cycle or just save the checkpoint at the end of the training.
+
+- `--total_cycles`, default=2, type: int
+	- Total amount of cycles to perform. For the moment the only available options are '1' or '2'.
+
+- `--cycle_def`, default="complete", type: str
+	- Train cycle definition. It can be: 'parametric', 'non-parametric', 'complete', 'only-non-parametric' and 'only-parametric'.
+## Evaluation flags
+### Saving paths
+
+- `--model_eval`, default="poly", type: str
+	- Model used as ground truth for the evaluation. Options are: 'poly', 'physical'.
+
+- `--metric_base_path`, default="/gpfswork/rech/ynx/ulx23va/wf-outputs/metrics/", type: str
+	- Base path for saving metric files.
+
+- `--saved_model_type`, default="final", type: str
+	- Type of saved model to use for the evaluation. Can be 'final' or 'checkpoint'.
+
+- `--saved_cycle`, default="cycle2", type: str
+	- Saved cycle to use for the evaluation. Can be 'cycle1' or 'cycle2'.
+### Evaluation parameters
+
+- `--gt_n_zernikes`, default=45, type: int
+	- Zernike polynomial modes to use on the ground truth model parametric part.
+
+- `--eval_batch_size`, default=16, type: int
+	- Batch size to use for the evaluation.
+
+- `--n_bins_gt`, default=20, type: int,
+help="Number of bins used for the ground truth model poly PSF generation."
+)
+
+- `--opt_stars_rel_pix_rmse`, default=False, type: bool
+	- Option to get SR pixel PSF RMSE for each individual test star.
+## Specific parameters
+
+- `--l2_param`, default=0., type: float
+	- Parameter for the l2 loss of the OPD.
+## Plot parameters
+
+- `--base_id_name`, default="-coherent_euclid_", type: str
+	- Plot parameter. Base id_name before dataset suffix are added.
+
+- `--suffix_id_name`, default=["2c", "5c"],
+multiple=True, type: str
+	- Plot parameter. Suffix needed to recreate the different id names.
+
+- `--star_numbers`, default=[200, 500],
+multiple=True, type: int
+	- Plot parameter. Training star number of the different models evaluated. Needs to correspond with the `suffix_id_name`.
+## WaveDiff new features
+### Feature: SED interp
+
+- `--interp_pts_per_bin`, default=0, type: int
+	- Number of points per bin to add during the interpolation process. It can take values {0,1,2,3}, where 0 means no interpolation.
+
+- `--extrapolate`, default=True, type: bool
+	- Whether extrapolation is performed or not on the borders of the SED.
+
+- `--SED_interp_kind`, default="linear", type: str
+	- Type of interpolation for the SED.
+### Feature: project parameters
+
+- `--project_dd_features`, default=False, type: bool
+	- Project NP DD features onto parametric model.

--- a/long-runs/train_eval_plot_script_click.py
+++ b/long-runs/train_eval_plot_script_click.py
@@ -3,6 +3,7 @@
 
 # PSF modelling and evaluation
 
+from email.policy import default
 import wf_psf as wf
 import click
 
@@ -165,30 +166,57 @@ import click
     default=32,
     type=int,
     help="Batch size used for the trainingin the stochastic gradient descend type of algorithm.")
+# Old multicycle parameters for backwards compatibility. 
 @click.option(
     "--l_rate_param",
     nargs=2,
-    default=[1e-2, 1e-2],
+    default=None,
     type=float,
     help="Learning rates for the parametric parts.")
 @click.option(
     "--l_rate_non_param",
     nargs=2,
-    default=[1e-1, 1e-1],
+    default=None,
     type=float,
     help="Learning rates for the non-parametric parts.")
 @click.option(
     "--n_epochs_param",
     nargs=2,
-    default=[20, 20],
+    default=None,
     type=int,
     help="Number of training epochs of the parametric parts.")
 @click.option(
     "--n_epochs_non_param",
     nargs=2,
-    default=[100, 120],
+    default=None,
     type=int,
     help="Number of training epochs of the non-parametric parts.")
+# New multicycle parameters
+@click.option(
+    "--l_rate_param_multi_cycle",
+    default="1e-2 1e-2",
+    type=str,
+    help="Learning rates for the parametric parts. It should be a strign where numeric values are separated by spaces.")
+@click.option(
+    "--l_rate_non_param_multi_cycle",
+    default="1e-1 1e-1",
+    type=str,
+    help="Learning rates for the non-parametric parts. It should be a strign where numeric values are separated by spaces.")
+@click.option(
+    "--n_epochs_param_multi_cycle",
+    default="20 20",
+    type=str,
+    help="Number of training epochs of the parametric parts. It should be a strign where numeric values are separated by spaces.")
+@click.option(
+    "--n_epochs_non_param_multi_cycle",
+    default="100 120",
+    type=str,
+    help="Number of training epochs of the non-parametric parts. It should be a strign where numeric values are separated by spaces.")
+@click.option(
+    "--save_all_cycles",
+    default=False,
+    type=bool,
+    help="Make checkpoint at every cycle or just save the checkpoint at the end of the training.")
 @click.option(
     "--total_cycles",
     default=2,
@@ -232,6 +260,17 @@ import click
     default=16,
     type=int,
     help="Batch size to use for the evaluation.")
+@click.option(
+    "--n_bins_gt",
+    default=20,
+    type=int,
+    help="Number of bins used for the ground truth model poly PSF generation."
+)
+@click.option(
+    "--opt_stars_rel_pix_rmse",
+    default=False,
+    type=bool,
+    help="Option to get SR pixel PSF RMSE for each individual test star.")
 ## Specific parameters
 @click.option(
     "--l2_param",
@@ -256,6 +295,28 @@ import click
     multiple=True,
     type=int,
     help="Plot parameter. Training star number of the different models evaluated. Needs to correspond with the `suffix_id_name`.")
+# Feature: SED interp
+@click.option(
+    "--interp_pts_per_bin",
+    default=0,
+    type=int,
+    help="Number of points per bin to add during the interpolation process. It can take values {0,1,2,3}, where 0 means no interpolation.")
+@click.option(
+    "--extrapolate",
+    default=True,
+    type=bool,
+    help="Whether extrapolation is performed or not on the borders of the SED.")
+@click.option(
+    "--SED_interp_kind",
+    default="linear",
+    type=str,
+    help="Type of interpolation for the SED.")
+# Feature: project parameters
+@click.option(
+    "--project_dd_features",
+    default=False,
+    type=bool,
+    help="Project NP DD features onto parametric model.")
 
 
 def main(**args):


### PR DESCRIPTION
New features added to the WaveDiff model. Now it can be optimised using any number of cycles. Options for the new projected DD features scenario are added.

New click options:

- `--save_all_cycles`: Make checkpoint at every cycle or just save the checkpoint at the end of the training.
- `--project_dd_features`: Project NP DD features onto parametric model.
- `--eval_only_param`: Use only the parametric model for evaluation.
- `--pretrained_model`: Path to pretrained model checkpoint callback.
- `--reset_dd_features`: Reset to random initialisation the non-parametric model after projecting.

