### PR TITLE
Bug Fix: Replacing Old Adam Optimizer with Legacy Optimizer

### DIFF
--- a/src/wf_psf/psf_models/tf_psf_field.py
+++ b/src/wf_psf/psf_models/tf_psf_field.py
@@ -1222,7 +1222,7 @@ def build_PSF_model(model_inst, optimizer=None, loss=None, metrics=None):
 
     # Define optimizer function
     if optimizer is None:
-        optimizer = tf.keras.optimizers.Adam(
+        optimizer = tf.keras.optimizers.legacy.Adam(
             learning_rate=1e-2, beta_1=0.9, beta_2=0.999, epsilon=1e-07, amsgrad=False
         )
 


### PR DESCRIPTION
## Bug Fix for Issue #88


### Validation Tests:


#### train_test.py
```bash
======================================= test session starts ========================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.3.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /content/drive/MyDrive/Github/wf-psf
configfile: pyproject.toml
plugins: cases-3.8.1, raises-0.11, black-0.3.12, cov-4.1.0, emoji-0.2.0, xdist-3.5.0, typeguard-2.13.3, anyio-3.7.1
collected 2 items                                                                                  

src/wf_psf/tests/train_test.py::BLACK PASSED 😃                                              [ 50%]
src/wf_psf/tests/train_test.py::test_train[training_params0] PASSED 😃                       [100%]
```
#### metrics_test.py
```bash
======================================= test session starts ========================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.3.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /content/drive/MyDrive/Github/wf-psf
configfile: pyproject.toml
plugins: cases-3.8.1, raises-0.11, black-0.3.12, cov-4.1.0, emoji-0.2.0, xdist-3.5.0, typeguard-2.13.3, anyio-3.7.1
collected 5 items                                                                                  

src/wf_psf/tests/metrics_test.py::BLACK PASSED 😃                                            [ 20%]
src/wf_psf/tests/metrics_test.py::test_eval_metrics_polychromatic_lowres[training_params0] PASSED 😃  [ 40%]
src/wf_psf/tests/metrics_test.py::test_evaluate_metrics_opd[training_params0] SKIPPED 🙄     [ 60%]
src/wf_psf/tests/metrics_test.py::test_eval_metrics_mono_rmse[training_params0] SKIPPED 🙄   [ 80%]
src/wf_psf/tests/metrics_test.py::test_evaluate_metrics_shape[training_params0] SKIPPED 🙄   [100%]
