### PR TITLE
Feature 92 ci ignore gpu tests

### DIFF
--- a/src/wf_psf/tests/metrics_test.py
+++ b/src/wf_psf/tests/metrics_test.py
@@ -107,7 +107,7 @@ def main_metrics(training_params):
     return np.load(os.path.join(main_dir, metrics_filename), allow_pickle=True)[()]
 
 
-@pytest.mark.skip(reason="Requires gpu")
+@pytest.mark.skipif("GITHUB_ENV" in os.environ, reason="Skipping GPU tests in CI")
 def test_eval_metrics_polychromatic_lowres(
     training_params,
     weights_path_basename,
@@ -155,7 +155,7 @@ def test_eval_metrics_polychromatic_lowres(
     assert ratio_rel_std_rmse < tol
 
 
-@pytest.mark.skip(reason="Requires gpu")
+@pytest.mark.skipif("GITHUB_ENV" in os.environ, reason="Skipping GPU tests in CI")
 def test_evaluate_metrics_opd(
     training_params,
     weights_path_basename,
@@ -205,7 +205,7 @@ def test_evaluate_metrics_opd(
     assert ratio_rel_rmse_std_opd < tol
 
 
-@pytest.mark.skip(reason="Requires gpu")
+@pytest.mark.skipif("GITHUB_ENV" in os.environ, reason="Skipping GPU tests in CI")
 def test_eval_metrics_mono_rmse(
     training_params,
     weights_path_basename,
@@ -270,7 +270,7 @@ def test_eval_metrics_mono_rmse(
     assert ratio_rel_rmse_std_mono < tol
 
 
-@pytest.mark.skip(reason="Requires gpu")
+@pytest.mark.skipif("GITHUB_ENV" in os.environ, reason="Skipping GPU tests in CI")
 def test_evaluate_metrics_shape(
     training_params,
     weights_path_basename,

--- a/src/wf_psf/tests/train_test.py
+++ b/src/wf_psf/tests/train_test.py
@@ -66,7 +66,7 @@ def psf_model_dir():
     )
 
 
-@pytest.mark.skip(reason="Requires gpu")
+@pytest.mark.skipif("GITHUB_ENV" in os.environ, reason="Skipping GPU tests in CI")
 def test_train(
     training_params,
     training_data,


### PR DESCRIPTION
This PR applies a fix raised in #92 regarding skipped validation tests.  We want the validation tests to be skipped during CI, but to be ran manually with `pytest` by the developer.  We applied the conditional `pytest.mark.skipif` decorator and will check if the CI environment variable was defined. If yes, the test is skipped, else the test is run.

Closes #92 