### PR TITLE
Bugfix to 95: Added Keras to pyproject dependencies list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-
+      - develop
 
 jobs:
   test-full:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ description = 'A software framework to perform Differentiable wavefront-based PS
 dependencies = [
     "numpy>=1.19.2",
     "scipy>=1.11.2",
+    "keras==2.9.0",
     "tensorflow>=2.9.1",
     "tensorflow-addons>=0.12.1",
     "tensorflow-estimator>=2.9.0",


### PR DESCRIPTION
solves #95 

Found solution in [StackOverflow](https://stackoverflow.com/questions/73270410/modulenotfounderror-no-module-named-tensorflow-python-trackable) 

Added Keras==2.9.0 to dependency list.
Ran `pytest` : no errors
Ran end-to-end: no errors