### PR TITLE
Fix Copy-Paste Error in Epochs Settings

### DIFF
--- a/src/wf_psf/training/train.py
+++ b/src/wf_psf/training/train.py
@@ -362,7 +362,7 @@ def train(
             learning_rate_non_param=training_handler.learning_rate_non_params[
                 current_cycle - 1
             ],
-            n_epochs_param=training_handler.n_epochs_non_params[current_cycle - 1],
+            n_epochs_param=training_handler.n_epochs_params[current_cycle - 1],
             n_epochs_non_param=training_handler.n_epochs_non_params[current_cycle - 1],
             param_optim=param_optim,
             non_param_optim=non_param_optim,


### PR DESCRIPTION
fix: correct duplicate 'n_epochs_non_params' in train.py

Please note that I couldn't test the changes as I currently don't have access to GPUs.