### PR TITLE
Added new CD workflow with manual trigger option

### DIFF
--- a/.github/workflows/cd_manual.yml
+++ b/.github/workflows/cd_manual.yml
@@ -1,0 +1,38 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: CD_Manual
+
+on: [workflow_dispatch]
+
+jobs:
+  docs:
+    name: Deploy API documentation
+    runs-on: [ubuntu-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Set up Python 3.10.5
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10.5"
+          
+      - name: Check Python Version
+        run: python --version
+
+      - name: Install dependencies
+        run: |
+          python -m pip install ".[docs]"
+     
+      - name: Build API documentation
+        run: |
+          sphinx-apidoc -Mfeo docs/source src/wf_psf
+          sphinx-build docs/source docs/build
+       
+      - name: Deploy API documentation
+        uses: peaceiris/actions-gh-pages@v3.5.9
+        with:
+           github_token: ${{ secrets.GITHUB_TOKEN }}
+           publish_dir: docs/build

--- a/.github/workflows/ci_manual.yml
+++ b/.github/workflows/ci_manual.yml
@@ -1,0 +1,25 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: CI_manual
+
+on: [workflow_dispatch]
+
+jobs:
+  test-full:
+    runs-on: [ubuntu-latest]
+
+    steps:
+      - name:
+        uses: actions/checkout@v3
+      
+      - name: Set up Python 3.10.5
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10.5"
+
+      - name: Install dependencies
+        run: python -m pip install ".[test]"
+       
+      - name: Test with pytest
+        run: python -m pytest


### PR DESCRIPTION
This PR is for adding a new CD workflow called `CD_Manual` that allows the user to manually trigger the workflow for a selected branch to run tests on the documentation.