### PR TITLE
Manual triggers for CI and CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       
-      - name: Set up Python 3.10.5
+      - name: Set up Python 3.10.11
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10.5"
+          python-version: "3.10.11"
           
       - name: Check Python Version
         run: python --version

--- a/.github/workflows/cd_manual.yml
+++ b/.github/workflows/cd_manual.yml
@@ -7,7 +7,7 @@ on: [workflow_dispatch]
 
 jobs:
   docs:
-    name: Deploy API documentation
+    name: Test API documentation build
     runs-on: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/cd_manual.yml
+++ b/.github/workflows/cd_manual.yml
@@ -31,8 +31,8 @@ jobs:
           sphinx-apidoc -Mfeo docs/source src/wf_psf
           sphinx-build docs/source docs/build
        
-      - name: Deploy API documentation
-        uses: peaceiris/actions-gh-pages@v3.5.9
+      - name: Archive documentation as artifact
+        uses: actions/upload-artifact@v2
         with:
-           github_token: ${{ secrets.GITHUB_TOKEN }}
-           publish_dir: docs/build
+          name: api-docs
+          path: docs/build

--- a/.github/workflows/cd_manual.yml
+++ b/.github/workflows/cd_manual.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       
-      - name: Set up Python 3.10.5
+      - name: Set up Python 3.10.11
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10.5"
+          python-version: "3.10.11"
           
       - name: Check Python Version
         run: python --version

--- a/.github/workflows/cd_manual.yml
+++ b/.github/workflows/cd_manual.yml
@@ -1,0 +1,38 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: CD_Manual
+
+on: [workflow_dispatch]
+
+jobs:
+  docs:
+    name: Deploy API documentation
+    runs-on: [ubuntu-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Set up Python 3.10.5
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10.5"
+          
+      - name: Check Python Version
+        run: python --version
+
+      - name: Install dependencies
+        run: |
+          python -m pip install ".[docs]"
+     
+      - name: Build API documentation
+        run: |
+          sphinx-apidoc -Mfeo docs/source src/wf_psf
+          sphinx-build docs/source docs/build
+       
+      - name: Deploy API documentation
+        uses: peaceiris/actions-gh-pages@v3.5.9
+        with:
+           github_token: ${{ secrets.GITHUB_TOKEN }}
+           publish_dir: docs/build

--- a/.github/workflows/ci_manual.yml
+++ b/.github/workflows/ci_manual.yml
@@ -9,14 +9,18 @@ jobs:
   test-full:
     runs-on: [ubuntu-latest]
 
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10"]
+
     steps:
       - name:
         uses: actions/checkout@v3
       
-      - name: Set up Python 3.10.5
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10.5"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: python -m pip install ".[test]"

--- a/.github/workflows/ci_manual.yml
+++ b/.github/workflows/ci_manual.yml
@@ -1,0 +1,25 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: CI_manual
+
+on: [workflow_dispatch]
+
+jobs:
+  test-full:
+    runs-on: [ubuntu-latest]
+
+    steps:
+      - name:
+        uses: actions/checkout@v3
+      
+      - name: Set up Python 3.10.5
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10.5"
+
+      - name: Install dependencies
+        run: python -m pip install ".[test]"
+       
+      - name: Test with pytest
+        run: python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ release = [
 ]
 
 test = [
-  "pytest",
+  "pytest>=7.0.0,<8.1",
   "pytest-cov",
   "pytest-emoji",
   "pytest-raises",


### PR DESCRIPTION
This PR includes two manual trigger workflows for CI and CD, respectively.
For CI_manual, we include a Python version matrix for versions 3.9 and 3.10 compatible with the latest release of WF-PSF. Python versions 3.11 and 3.12 requires upgrades to WF-PSF TensorFlow and TensorFlow Add-on packages.
For CD.yml and CD_manual.yml, we also bumped up the Python version to 3.10.11.

Due to CI failures with `pytest==8.1.x` (https://github.com/CosmoStat/wf-psf/issues/125) and deprecated pytest-plugins (https://github.com/CosmoStat/wf-psf/issues/118), I locked `pytest>=7.0.0,<8.1' and removed deprecated pytest-plugins.

Solves #118 and #125.
 
Ran CI and CD tests in forked repo: https://github.com/jeipollack/wf-psf/actions