### PR TITLE
Feature/81/eliminate repodir dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ quote-style = "double"
 indent-style = "space"
 line-ending = "lf"
 
+[tool.setuptools.package-data]
+"wf_psf.config" = ["*.conf"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/src/wf_psf/config/logging.conf
+++ b/src/wf_psf/config/logging.conf
@@ -1,0 +1,33 @@
+[loggers]
+keys=root, simpleLogger
+
+[handlers]
+keys=consoleHandler, fileHandler
+
+[formatters]
+keys=simpleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler, fileHandler
+
+[logger_simpleLogger]
+level=DEBUG
+handlers=consoleHandler, fileHandler
+qualname=simpleLogger
+propagate=0
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=simpleFormatter
+args=(sys.stdout,)
+
+[handler_fileHandler]
+class=FileHandler
+level=DEBUG
+formatter=simpleFormatter
+args=('%(filename)s', 'w')
+
+[formatter_simpleFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/src/wf_psf/run.py
+++ b/src/wf_psf/run.py
@@ -38,14 +38,6 @@ def setProgramOptions():
     )
 
     parser.add_argument(
-        "--repodir",
-        "-r",
-        type=str,
-        required=True,
-        help="the path of the code repository directory.",
-    )
-
-    parser.add_argument(
         "--outputdir",
         "-o",
         type=str,
@@ -71,7 +63,7 @@ def mainMethod():
     configs = read_stream(args.conffile)
     configs_file = os.path.basename(args.conffile)
 
-    file_handler = FileIOHandler(args.repodir, args.outputdir, configs_path)
+    file_handler = FileIOHandler(args.outputdir, configs_path)
     file_handler.setup_outputs()
     file_handler.copy_conffile_to_output_dir(configs_file)
 

--- a/src/wf_psf/tests/test_utils/configs_handler_test.py
+++ b/src/wf_psf/tests/test_utils/configs_handler_test.py
@@ -98,7 +98,7 @@ def test_set_run_config():
 
 def test_get_run_config(path_to_repo_dir, path_to_tmp_output_dir, path_to_config_dir):
     test_file_handler = FileIOHandler(
-        path_to_repo_dir, path_to_tmp_output_dir, path_to_config_dir
+        path_to_tmp_output_dir, path_to_config_dir
     )
 
     config_class = configs_handler.get_run_config(
@@ -237,10 +237,10 @@ def test_run_method_calls_train_with_correct_arguments(
 
 
 def test_MetricsConfigHandler_weights_basename_filepath(
-    path_to_repo_dir, path_to_tmp_output_dir, path_to_config_dir
+    path_to_tmp_output_dir, path_to_config_dir
 ):
     test_file_handler = FileIOHandler(
-        path_to_repo_dir, path_to_tmp_output_dir, path_to_config_dir
+        path_to_tmp_output_dir, path_to_config_dir
     )
 
     metrics_config_file = "validation/main_random_seed/config/metrics_config.yaml"

--- a/src/wf_psf/tests/test_utils/configs_handler_test.py
+++ b/src/wf_psf/tests/test_utils/configs_handler_test.py
@@ -96,10 +96,8 @@ def test_set_run_config():
     assert config_class == configs_handler.PlottingConfigHandler
 
 
-def test_get_run_config(path_to_repo_dir, path_to_tmp_output_dir, path_to_config_dir):
-    test_file_handler = FileIOHandler(
-        path_to_tmp_output_dir, path_to_config_dir
-    )
+def test_get_run_config(path_to_tmp_output_dir, path_to_config_dir):
+    test_file_handler = FileIOHandler(path_to_tmp_output_dir, path_to_config_dir)
 
     config_class = configs_handler.get_run_config(
         "test_conf", "fake_config.yaml", test_file_handler
@@ -108,9 +106,7 @@ def test_get_run_config(path_to_repo_dir, path_to_tmp_output_dir, path_to_config
     assert type(config_class) is RegisterConfigClass
 
 
-def test_data_config_handler_init(
-    mock_training_conf, mock_data_read_conf, mocker
-):
+def test_data_config_handler_init(mock_training_conf, mock_data_read_conf, mocker):
     # Mock read_conf function
     mock_data_read_conf()
 
@@ -126,7 +122,7 @@ def test_data_config_handler_init(
 
     # Create DataConfigHandler instance
     data_config_handler = DataConfigHandler(
-        "/path/to/data_config.yaml", 
+        "/path/to/data_config.yaml",
         mock_training_conf.training.model_params,
         mock_training_conf.training.training_hparams.batch_size,
     )
@@ -142,7 +138,10 @@ def test_data_config_handler_init(
         data_config_handler.test_data.n_bins_lambda
         == mock_training_conf.training.model_params.n_bins_lda
     )
-    assert (data_config_handler.batch_size == mock_training_conf.training.training_hparams.batch_size)  # Default value
+    assert (
+        data_config_handler.batch_size
+        == mock_training_conf.training.training_hparams.batch_size
+    )  # Default value
 
 
 def test_training_config_handler_init(mocker, mock_training_conf, mock_file_handler):
@@ -180,10 +179,6 @@ def test_training_config_handler_init(mocker, mock_training_conf, mock_file_hand
     )
     assert training_config_handler.training_conf == mock_training_conf
     assert training_config_handler.file_handler == mock_file_handler
-    assert (
-        training_config_handler.file_handler.repodir_path
-        == mock_file_handler.repodir_path
-    )
 
     mock_data_conf.assert_called_once_with(
         os.path.join(
@@ -239,9 +234,7 @@ def test_run_method_calls_train_with_correct_arguments(
 def test_MetricsConfigHandler_weights_basename_filepath(
     path_to_tmp_output_dir, path_to_config_dir
 ):
-    test_file_handler = FileIOHandler(
-        path_to_tmp_output_dir, path_to_config_dir
-    )
+    test_file_handler = FileIOHandler(path_to_tmp_output_dir, path_to_config_dir)
 
     metrics_config_file = "validation/main_random_seed/config/metrics_config.yaml"
 

--- a/src/wf_psf/tests/test_utils/conftest.py
+++ b/src/wf_psf/tests/test_utils/conftest.py
@@ -10,7 +10,6 @@ wf_psf utils package.
 
 import pytest
 import os
-from wf_psf.utils.read_config import RecursiveNamespace
 from wf_psf.utils.io import FileIOHandler
 
 cwd = os.getcwd()
@@ -24,6 +23,11 @@ def path_to_repo_dir():
 @pytest.fixture
 def path_to_tmp_output_dir(tmp_path):
     return tmp_path
+
+
+@pytest.fixture
+def path_to_test_dir(path_to_repo_dir):
+    return os.path.join(path_to_repo_dir, "src", "wf_psf", "tests")
 
 
 @pytest.fixture

--- a/src/wf_psf/tests/test_utils/conftest.py
+++ b/src/wf_psf/tests/test_utils/conftest.py
@@ -22,11 +22,6 @@ def path_to_repo_dir():
 
 
 @pytest.fixture
-def path_to_test_dir(path_to_repo_dir):
-    return os.path.join(path_to_repo_dir, "src", "wf_psf", "tests")
-
-
-@pytest.fixture
 def path_to_tmp_output_dir(tmp_path):
     return tmp_path
 
@@ -44,7 +39,6 @@ def mock_file_handler(mocker, tmp_path):
 
     # Create a mock FileIOHandler instance
     mock_fh = FileIOHandler(
-        repodir_path="/path/to/repo",
         output_path="/path/to/output",
         config_path=str(temp_dir),
     )

--- a/src/wf_psf/tests/test_utils/conftest.py
+++ b/src/wf_psf/tests/test_utils/conftest.py
@@ -26,13 +26,8 @@ def path_to_tmp_output_dir(tmp_path):
 
 
 @pytest.fixture
-def path_to_test_dir(path_to_repo_dir):
-    return os.path.join(path_to_repo_dir, "src", "wf_psf", "tests")
-
-
-@pytest.fixture
-def path_to_config_dir(path_to_test_dir):
-    return os.path.join(path_to_test_dir, "data")
+def path_to_config_dir(path_to_repo_dir):
+    return os.path.join(path_to_repo_dir, "src", "wf_psf", "tests", "data")
 
 
 @pytest.fixture

--- a/src/wf_psf/tests/test_utils/io_test.py
+++ b/src/wf_psf/tests/test_utils/io_test.py
@@ -13,10 +13,8 @@ import os
 
 
 @pytest.fixture
-def test_file_handler(path_to_repo_dir, path_to_tmp_output_dir, path_to_config_dir):
-    test_file_handler = FileIOHandler(
-        path_to_repo_dir, path_to_tmp_output_dir, path_to_config_dir
-    )
+def test_file_handler(path_to_tmp_output_dir, path_to_config_dir):
+    test_file_handler = FileIOHandler(path_to_tmp_output_dir, path_to_config_dir)
     test_file_handler._make_output_dir()
     test_file_handler._make_run_dir()
     test_file_handler._setup_dirs()
@@ -51,6 +49,7 @@ def test_setup_dirs(test_file_handler):
             )
         )
 
+
 def test_setup_logging_uses_files_and_fileconfig(mocker, path_to_tmp_output_dir):
     """
     Ensure that _setup_logging correctly loads logging.conf from package resources
@@ -64,39 +63,39 @@ def test_setup_logging_uses_files_and_fileconfig(mocker, path_to_tmp_output_dir)
     fh._make_output_dir()
     fh._make_run_dir()
     fh._setup_dirs()
-    
+
     # --- Mock importlib.resources.files() and as_file() ---
     mock_files = mocker.patch("importlib.resources.files")
     mock_as_file = mocker.patch("importlib.resources.as_file")
-    
+
     mock_config_files = mocker.MagicMock()
     mock_files.return_value = mock_config_files
-    
+
     mock_conf_resource = mocker.MagicMock()
     mock_config_files.joinpath.return_value = mock_conf_resource
-    
+
     mock_conf_path = mocker.MagicMock()
     mock_as_file.return_value.__enter__.return_value = mock_conf_path
-    
+
     # --- Mock logging.config.fileConfig ---
     mock_fileconfig = mocker.patch("logging.config.fileConfig")
-    
+
     # Run method
     fh._setup_logging()
-    
+
     # --- Assertions ---
     mock_files.assert_called_once_with("wf_psf.config")
     mock_config_files.joinpath.assert_called_once_with("logging.conf")
     mock_as_file.assert_called_once_with(mock_conf_resource)
-    
+
     mock_fileconfig.assert_called_once()
     args, kwargs = mock_fileconfig.call_args
-    
+
     assert args[0] is mock_conf_path
     assert "defaults" in kwargs
     assert "filename" in kwargs["defaults"]
     assert kwargs["disable_existing_loggers"] is False
-    
+
     logfile = kwargs["defaults"]["filename"]
     assert logfile.startswith(str(fh._run_output_dir))
     assert logfile.endswith(".log")

--- a/src/wf_psf/tests/test_utils/io_test.py
+++ b/src/wf_psf/tests/test_utils/io_test.py
@@ -50,3 +50,55 @@ def test_setup_dirs(test_file_handler):
                 test_file_handler._run_output_dir, test_file_handler.__dict__[odir]
             )
         )
+
+def test_setup_logging_uses_resources_and_fileconfig(mocker, path_to_tmp_output_dir):
+    """
+    Ensure that _setup_logging correctly loads logging.conf from package resources
+    and calls logging.config.fileConfig with the expected arguments.
+    """
+    # Create handler
+    fh = FileIOHandler(
+        output_path=str(path_to_tmp_output_dir),
+        config_path="/unused",   # not used by _setup_logging anymore
+    )
+
+    # Ensure dir structure exists
+    fh._make_output_dir()
+    fh._make_run_dir()
+    fh._setup_dirs()
+
+    # --- Mock importlib.resources.path ---
+    mock_resources_path = mocker.patch("importlib.resources.path")
+    
+    # Mock context manager returned by resources.path
+    mock_conf_path = mocker.MagicMock()
+    mock_resources_path.return_value.__enter__.return_value = mock_conf_path
+
+    # --- Mock logging.config.fileConfig ---
+    mock_fileconfig = mocker.patch("logging.config.fileConfig")
+
+    # Run method
+    fh._setup_logging()
+
+    # --- Assertions ---
+    # Correct package is requested
+    mock_resources_path.assert_called_once_with("wf_psf.config", "logging.conf")
+
+    # fileConfig is invoked with correct keyword args
+    mock_fileconfig.assert_called_once()
+
+    args, kwargs = mock_fileconfig.call_args
+
+    # First positional argument is the config file path from resources.path
+    assert args[0] is mock_conf_path
+
+    # logfile default injected via defaults={"filename": ...}
+    assert "defaults" in kwargs
+    assert "filename" in kwargs["defaults"]
+    assert kwargs["disable_existing_loggers"] is False
+
+    # Ensure logfile path follows expected structure
+    logfile = kwargs["defaults"]["filename"]
+    assert logfile.startswith(str(fh._run_output_dir))
+    assert logfile.endswith(".log")
+

--- a/src/wf_psf/utils/io.py
+++ b/src/wf_psf/utils/io.py
@@ -129,7 +129,7 @@ class FileIOHandler:
 
         """
         import logging.config
-        from importlib import resources
+        from importlib.resources import files, as_file 
         
         logfile = "wf-psf_" + self._timestamp + ".log"
         logfile = os.path.join(
@@ -138,14 +138,16 @@ class FileIOHandler:
             logfile,
         )
 
-        # Load the package-internal logging.conf
-        with resources.path("wf_psf.config", "logging.conf") as conf_path:
+        config_files = files("wf_psf.config")
+        conf_resource = config_files.joinpath("logging.conf")
+        
+        with as_file(conf_resource) as conf_path:
             logging.config.fileConfig(
                 conf_path,
                 defaults={"filename": logfile},
                 disable_existing_loggers=False,
             )
-
+    
     def _make_dir(self, dir_name):
         """Make Directory.
 

--- a/src/wf_psf/utils/io.py
+++ b/src/wf_psf/utils/io.py
@@ -29,8 +29,7 @@ class FileIOHandler:
 
     """
 
-    def __init__(self, repodir_path, output_path, config_path):
-        self.repodir_path = repodir_path
+    def __init__(self, output_path, config_path):
         self.output_path = output_path
         self.config_path = config_path
         self._timestamp = self.get_timestamp()
@@ -129,17 +128,23 @@ class FileIOHandler:
         logging.
 
         """
+        import logging.config
+        from importlib import resources
+        
         logfile = "wf-psf_" + self._timestamp + ".log"
         logfile = os.path.join(
             self._run_output_dir,
             self._log_files,
             logfile,
         )
-        logging.config.fileConfig(
-            os.path.join(self.repodir_path, "config/logging.conf"),
-            defaults={"filename": logfile},
-            disable_existing_loggers=False,
-        )
+
+        # Load the package-internal logging.conf
+        with resources.path("wf_psf.config", "logging.conf") as conf_path:
+            logging.config.fileConfig(
+                conf_path,
+                defaults={"filename": logfile},
+                disable_existing_loggers=False,
+            )
 
     def _make_dir(self, dir_name):
         """Make Directory.


### PR DESCRIPTION
### Description
This PR removes the `--repodir` argument and updates` _setup_logging()` to load `logging.conf` from package-internal resources, simplifying the CLI and ensuring logging works reliably in HPC and batch jobs.

### Problem

Previously, WaveDiff required the `--repodir` argument only to locate `logging.conf` in the repository. This approach places an unnecessary requirement on users.

### Solution

- Removed `--repodir` references from CLI and code.
- Moved `logging.conf` into src/wf_psf/config/ as package data.
- `_setup_logging()` now uses `importlib.resources.path` with module-level import.
- Added optional fallback for development environments.
- Updated pytest tests to mock `resources.path` and `logging.config.fileConfig`.

### Testing

- Unit tests verify correct resource lookup, logfile path, and logging configuration.
- Existing directory setup methods remain functional.
- Successful code execution without `--repodir`.

### Related Issues
Fixes #81