### PR TITLE
Bug: Fix optimizer legacy error and type error

### DIFF
--- a/src/wf_psf/metrics/metrics.py
+++ b/src/wf_psf/metrics/metrics.py
@@ -12,7 +12,7 @@ import numpy as np
 import tensorflow as tf
 import galsim as gs
 import wf_psf.utils.utils as utils
-from wf_psf.psf_models.psf_models import build_PSF_model
+from wf_psf.psf_models.psf_models import compile_PSF_model
 from wf_psf.sims import psf_simulator as psf_simulator
 import logging
 
@@ -446,11 +446,11 @@ def compute_shape_metrics(
     tf_semiparam_field.set_output_Q(output_Q=output_Q, output_dim=output_dim)
     gt_tf_semiparam_field.set_output_Q(output_Q=output_Q, output_dim=output_dim)
 
-    # Need to compile the models again
-    tf_semiparam_field = build_PSF_model(
+    # Re-compile PSF model
+    tf_semiparam_field = compile_PSF_model(
         tf_semiparam_field, optimizer=optimizer_settings
     )
-    gt_tf_semiparam_field = build_PSF_model(
+    gt_tf_semiparam_field = compile_PSF_model(
         gt_tf_semiparam_field, optimizer=optimizer_settings
     )
 
@@ -614,9 +614,9 @@ def compute_shape_metrics(
         output_Q=gt_original_out_Q, output_dim=gt_original_out_dim
     )
 
-    # Need to compile the models again
-    tf_semiparam_field = build_PSF_model(tf_semiparam_field)
-    gt_tf_semiparam_field = build_PSF_model(gt_tf_semiparam_field)
+    # Re-compile PSF models
+    tf_semiparam_field = compile_PSF_model(tf_semiparam_field)
+    gt_tf_semiparam_field = compile_PSF_model(gt_tf_semiparam_field)
 
     # Moment results
     result_dict = {

--- a/src/wf_psf/psf_models/psf_models.py
+++ b/src/wf_psf/psf_models/psf_models.py
@@ -152,11 +152,28 @@ def get_psf_model(*psf_model_params):
     return psf_factory_class().get_model_instance(*psf_model_params)
 
 
-def build_PSF_model(model_inst, optimizer=None, loss=None, metrics=None):
-    """Define the model-compilation parameters.
+def compile_PSF_model(model_inst, optimizer=None, loss=None, metrics=None):
+    """Compile PSF Model.
 
-    Specially the loss function, the optimizer and the metrics.
-    """
+    A function to compile a PSF model instance.
+
+    Parameters
+    ----------
+    model_inst: PSF model instance
+        An instance of the PSF model to be compiled.
+    optimizer: str, dict, or Keras optimizer instance, optional
+        The optimizer to use for compiling the model. It can be a string representing the optimizer name, a dictionary containing optimizer configuration, or an instance of a Keras optimizer. Defaults to None, which will use the default optimizer.
+    loss: str or Keras loss instance, optional
+        The loss function to use for compiling the model. It can be a string representing the loss function name or an instance of a Keras loss. Defaults to None, which will use the default loss function.
+    metrics: list of str or Keras metric instances, optional
+        A list of metrics to evaluate during training. Each metric can be a string representing the metric name or an instance of a Keras metric. Defaults to None, which will use the default metrics
+            (Mean Squared Error in this case).
+
+    Returns
+    -------
+    PSF model instance
+        The compiled PSF model instance ready for training.
+    """ 
     # Define model loss function
     if loss is None:
         loss = tf.keras.losses.MeanSquaredError()
@@ -166,7 +183,7 @@ def build_PSF_model(model_inst, optimizer=None, loss=None, metrics=None):
         pass
     else:
         optimizer = get_optimizer(optimizer_config=optimizer)
-    
+   
     # Define metric functions
     if metrics is None:
         metrics = [tf.keras.metrics.MeanSquaredError()]
@@ -183,6 +200,33 @@ def build_PSF_model(model_inst, optimizer=None, loss=None, metrics=None):
 
     return model_inst
 
+def rebuild_PSF_model_for_evaluation(model, output_Q, output_dim):
+    """Reuild PSF Model for Evaluation.
+
+    Adjust the PSF model to produce outputs with the desired sampling/output_dim
+    for metric evaluation. Does NOT set optimizer, loss, or metrics.
+
+    Parameters
+    ----------
+    model: PSF model instance
+        An instance of the PSF model to be adjusted for evaluation.
+    output_Q: int
+        The desired output sampling for the PSF model during evaluation.
+    output_dim: int
+        The desired output dimension for the PSF model during evaluation.
+
+    Returns
+    -------
+    PSF model instance
+        The PSF model instance adjusted to produce outputs with the specified sampling and dimension for evaluation.
+
+    """
+    model.set_output_Q(output_Q=output_Q, output_dim=output_dim)
+    # Optionally trigger Keras to rebuild layers if needed
+    if hasattr(model, "build"):
+        # Provide a dummy input shape if required
+        model.build(input_shape=[None, model.input_shape[-1]])
+    return model
 
 def get_psf_model_weights_filepath(weights_filepath):
     """Get PSF model weights filepath.

--- a/src/wf_psf/psf_models/psf_models.py
+++ b/src/wf_psf/psf_models/psf_models.py
@@ -173,7 +173,7 @@ def compile_PSF_model(model_inst, optimizer=None, loss=None, metrics=None):
     -------
     PSF model instance
         The compiled PSF model instance ready for training.
-    """ 
+    """
     # Define model loss function
     if loss is None:
         loss = tf.keras.losses.MeanSquaredError()
@@ -183,7 +183,7 @@ def compile_PSF_model(model_inst, optimizer=None, loss=None, metrics=None):
         pass
     else:
         optimizer = get_optimizer(optimizer_config=optimizer)
-   
+
     # Define metric functions
     if metrics is None:
         metrics = [tf.keras.metrics.MeanSquaredError()]
@@ -200,33 +200,6 @@ def compile_PSF_model(model_inst, optimizer=None, loss=None, metrics=None):
 
     return model_inst
 
-def rebuild_PSF_model_for_evaluation(model, output_Q, output_dim):
-    """Reuild PSF Model for Evaluation.
-
-    Adjust the PSF model to produce outputs with the desired sampling/output_dim
-    for metric evaluation. Does NOT set optimizer, loss, or metrics.
-
-    Parameters
-    ----------
-    model: PSF model instance
-        An instance of the PSF model to be adjusted for evaluation.
-    output_Q: int
-        The desired output sampling for the PSF model during evaluation.
-    output_dim: int
-        The desired output dimension for the PSF model during evaluation.
-
-    Returns
-    -------
-    PSF model instance
-        The PSF model instance adjusted to produce outputs with the specified sampling and dimension for evaluation.
-
-    """
-    model.set_output_Q(output_Q=output_Q, output_dim=output_dim)
-    # Optionally trigger Keras to rebuild layers if needed
-    if hasattr(model, "build"):
-        # Provide a dummy input shape if required
-        model.build(input_shape=[None, model.input_shape[-1]])
-    return model
 
 def get_psf_model_weights_filepath(weights_filepath):
     """Get PSF model weights filepath.

--- a/src/wf_psf/training/train_utils.py
+++ b/src/wf_psf/training/train_utils.py
@@ -12,7 +12,7 @@ Authors: Tobias Liaudat <tobias.liaudat@cea.fr>, Ezequiel Centofanti <ezequiel.c
 import numpy as np
 import tensorflow as tf
 from typing import Optional, Callable, Union
-from wf_psf.psf_models.psf_models import build_PSF_model
+from wf_psf.psf_models.psf_models import compile_PSF_model
 from wf_psf.utils.utils import NoiseEstimator, generalised_sigmoid
 import logging
 
@@ -511,8 +511,8 @@ def train_cycle_part(
     -----
     This function trains the model based on the provided `cycle_part`. If `cycle_part` is set to
     "parametric", the function assumes the model is being trained in a parametric setting, while
-    "non-parametric" indicates the training of a non-parametric part. The model is built using the
-    `build_PSF_model` function before fitting.
+    "non-parametric" indicates the training of a non-parametric part. The model is compile using the
+    `compile_PSF_model` function before fitting.
 
     Examples
     --------
@@ -533,7 +533,7 @@ def train_cycle_part(
     """
     logger.info(f"Starting {cycle_part} update..")
 
-    psf_model = build_PSF_model(
+    psf_model = compile_PSF_model(
         psf_model, optimizer=optimizer, loss=loss, metrics=metrics
     )
 

--- a/src/wf_psf/utils/optimizer.py
+++ b/src/wf_psf/utils/optimizer.py
@@ -7,8 +7,6 @@ This module provides utility functions to create optimizers for training or eval
 """
 
 import tensorflow as tf
-import logging
-
 
 def is_optimizer_instance(obj):
     return hasattr(obj, "apply_gradients") and hasattr(obj, "get_config")

--- a/src/wf_psf/utils/optimizer.py
+++ b/src/wf_psf/utils/optimizer.py
@@ -7,6 +7,7 @@ This module provides utility functions to create optimizers for training or eval
 """
 
 import tensorflow as tf
+import logging
 
 
 def is_optimizer_instance(obj):
@@ -30,7 +31,7 @@ def get_optimizer(optimizer_config=None, **overrides):
     """
     # Detect TensorFlow version
     version = tuple(map(int, tf.__version__.split(".")[:2]))
-    is_legacy = version < (2, 11)
+    is_legacy = version <= (2, 11)
 
     # --- Normalize input to a dictionary
     if isinstance(optimizer_config, str):
@@ -52,7 +53,7 @@ def get_optimizer(optimizer_config=None, **overrides):
     optimizer_params.update(overrides)
 
     # Extract learning_rate
-    learning_rate = optimizer_params.pop("learning_rate", 1e-3)
+    learning_rate = float(optimizer_params.pop("learning_rate", 1e-3))
 
     # --- Rectified Adam (TensorFlow Addons)
     if optimizer_name in ["rectified_adam", "radam"]:
@@ -72,9 +73,9 @@ def get_optimizer(optimizer_config=None, **overrides):
         )
         return opt_cls(
             learning_rate=learning_rate,
-            beta_1=optimizer_params.get("beta_1", 0.9),
-            beta_2=optimizer_params.get("beta_2", 0.999),
-            epsilon=optimizer_params.get("epsilon", 1e-07),
+            beta_1=float(optimizer_params.get("beta_1", 0.9)),
+            beta_2=float(optimizer_params.get("beta_2", 0.999)),
+            epsilon=float(optimizer_params.get("epsilon", 1e-07)),
             amsgrad=optimizer_params.get("amsgrad", False),
         )
 


### PR DESCRIPTION
## Summary

Bug fixes to optimizer configuration.

Closes #203 


## What’s changed


- Mismatch between optimizer packages used during training and metrics evaluation
  - Fixed by setting `is_legacy <= 2.11`
- Type error in optimizer configuration parameters
  - Fixed by converting optimizer config params to `float`.

Additional changes:

- Rename `build_PSF_model` to `compile_PSF_model` to match actual function behaviour


## How to test / verify

- Run wavediff training and metrics tasks
- Verify code execution completes without errors and results reproducible


## Scope

> Indicate the type of PR:

- [ ] Feature  
- [X] Bug fix  
- [ ] Hotfix  
- [ ] Documentation / process change  
- [ ] Internal / refactor  
- [ ] Release

> Optionally, note if this PR is part of a larger milestone or set of related PRs.


## Changelog

> Did this PR introduce user-visible changes?  No, addressed in previous PR
> If yes, a **Scriv changelog fragment** must be added and committed.

- [ ] Changelog fragment added (if applicable)


## Reviewer Checklist

> Reviewers should confirm the following before approving and merging:

- [x] The PR targets the correct base branch (`develop`, or `main` for release PRs)
- [x] The PR is assigned to the developer
- [x] Appropriate labels are applied
- [x] The PR is included in relevant projects and/or milestones
- [x] Description clearly explains what has changed
- [x] Issue references included, if applicable
- [x] Code and documentation adhere to current standards (`ruff`)
- [x] Documentation updates included, if relevant
- [x] CI tests are passing
- [x] All reviewer comments have been addressed


## Next Steps / Notes (if applicable)

> Any follow-up actions, known issues, or reminders for maintainers.

