### PR TITLE
refactor: reorganize config handlers with ABC and modular structure

### DIFF
--- a/changelog.d/20260225_104813_jennifer.pollack_refactor_config_handler.md
+++ b/changelog.d/20260225_104813_jennifer.pollack_refactor_config_handler.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+
+### Breaking changes
+
+- Config handlers moved to their respective task packages. Import paths changed:
+  - `TrainingConfigHandler`: now in `wf_psf.training.training_config_handler`
+  - `MetricsConfigHandler`: now in `wf_psf.metrics.metrics_config_handler`
+  - `PlottingConfigHandler`: now in `wf_psf.plotting.plotting_config_handler`
+  - `DataConfigHandler`: now in `wf_psf.data.data_config_handler`
+  - Backward compatibility maintained via `wf_psf.utils.configs_handler`
+
+
+### New features
+
+- Added `ConfigHandler` abstract base class for type safety and enforced interface compliance
+- All config handlers now inherit from `ConfigHandler` ABC and must implement `run()` method
+- Config handler registry pattern enhanced with ABC enforcement
+
+### Bug fixes
+
+- A bullet item for the Bug fixes category.
+
+-->
+<!--
+### Performance improvements
+
+- A bullet item for the Performance improvements category.
+
+-->
+
+### Internal changes
+
+- Reorganized config handlers into modular structure with each handler in its task package
+- Improved config handler registration system with abstract base class
+- Enhanced test coverage for config handler ABC enforcement and registry dispatch
+- Registry imports handlers automatically when `wf_psf` package is imported

--- a/src/wf_psf/__init__.py
+++ b/src/wf_psf/__init__.py
@@ -5,3 +5,9 @@ importlib.import_module("wf_psf.psf_models.psf_models")
 importlib.import_module("wf_psf.psf_models.models.psf_model_semiparametric")
 importlib.import_module("wf_psf.psf_models.models.psf_model_physical_polychromatic")
 importlib.import_module("wf_psf.psf_models.tf_modules.tf_psf_field")
+
+# Register config handlers
+importlib.import_module("wf_psf.training.training_config_handler")
+importlib.import_module("wf_psf.metrics.metrics_config_handler")
+importlib.import_module("wf_psf.plotting.plotting_config_handler")
+importlib.import_module("wf_psf.data.data_config_handler")

--- a/src/wf_psf/data/data_config_handler.py
+++ b/src/wf_psf/data/data_config_handler.py
@@ -1,0 +1,74 @@
+"""DataConfigHandler.
+
+A module which provides a class to manage the parameters of the data config file.
+
+:Authors: Jennifer Pollack <jennifer.pollack@cea.fr>
+
+"""
+
+from wf_psf.utils.configs_handler import ConfigHandler
+from wf_psf.data.data_handler import DataHandler
+from wf_psf.utils.read_config import read_conf
+from wf_psf.psf_models import psf_models
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class DataConfigHandler(ConfigHandler):
+    """DataConfigHandler.
+
+    A class to handle data configuration
+    parameters.
+
+    Parameters
+    ----------
+    data_conf : str
+        Path of the data configuration file
+    training_model_params : Recursive Namespace object
+        Recursive Namespace object containing the training model parameters
+    batch_size : int
+       Training hyperparameter used for batched pre-processing of data.
+
+    """
+
+    ids = ("data_conf",)
+
+    def __init__(self, data_conf, training_model_params, batch_size=16, load_data=True):
+        try:
+            self.data_conf = read_conf(data_conf)
+        except (FileNotFoundError, TypeError) as e:
+            logger.exception(e)
+            exit()
+
+        self.simPSF = psf_models.simPSF(training_model_params)
+
+        # Extract sub-configs early
+        train_params = self.data_conf.data.training
+        test_params = self.data_conf.data.test
+
+        self.training_data = DataHandler(
+            dataset_type="training",
+            data_params=train_params,
+            simPSF=self.simPSF,
+            n_bins_lambda=training_model_params.n_bins_lda,
+            load_data=load_data,
+        )
+        self.test_data = DataHandler(
+            dataset_type="test",
+            data_params=test_params,
+            simPSF=self.simPSF,
+            n_bins_lambda=training_model_params.n_bins_lda,
+            load_data=load_data,
+        )
+
+        self.batch_size = batch_size
+
+    def run(self):
+        """Run DataConfigHandler.
+
+        A function to run the data configuration handler.
+
+        """
+        raise NotImplementedError

--- a/src/wf_psf/metrics/metrics_config_handler.py
+++ b/src/wf_psf/metrics/metrics_config_handler.py
@@ -1,0 +1,297 @@
+"""MetricsConfigHandler.
+
+A module containing the MetricsConfigHandler class, which is responsible for managing the parameters of the metrics configuration file and running the
+metrics evaluation of a trained PSF model
+
+:Authors: Jennifer Pollack <jennifer.pollack@cea.fr>
+
+"""
+
+import os
+from wf_psf.utils.configs_handler import (
+    ConfigHandler,
+    register_configclass,
+    ConfigParameterError,
+)
+from wf_psf.data.data_config_handler import DataConfigHandler
+from wf_psf.utils.read_config import read_conf
+from wf_psf.metrics.metrics_interface import evaluate_model
+from wf_psf.psf_models.psf_model_loader import load_trained_psf_model
+from wf_psf.plotting.plotting_config_handler import PlottingConfigHandler
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@register_configclass
+class MetricsConfigHandler(ConfigHandler):
+    """MetricsConfigHandler.
+
+    A class to handle metrics configuation
+    parameters.
+
+    Parameters
+    ----------
+    ids: tuple
+        A tuple containing a string id for the Configuration Class
+    metrics_conf: str
+        Path to the metrics configuration file
+    file_handler: object
+        An instance of the FileIOHandler
+    training_conf: RecursiveNamespace object
+        RecursiveNamespace object containing the training configuration parameters
+
+
+    """
+
+    ids = ("metrics_conf",)
+
+    def __init__(self, metrics_conf, file_handler, training_conf=None):
+        self._metrics_conf = read_conf(metrics_conf)
+        self._file_handler = file_handler
+        self.training_conf = training_conf
+        self.data_conf = self._load_data_conf()
+        self.data_conf.run_type = "metrics"
+        self.metrics_dir = self._file_handler.get_metrics_dir(
+            self._file_handler._run_output_dir
+        )
+        self.trained_psf_model = self._load_trained_psf_model()
+
+    @property
+    def metrics_conf(self):
+        """Get Metrics Conf.
+
+        A function to return the metrics configuration file name.
+
+        Returns
+        -------
+        RecursiveNamespace
+            An instance of the metrics configuration file.
+        """
+        return self._metrics_conf
+
+    @property
+    def training_conf(self):
+        """Returns the loaded training configuration."""
+        return self._training_conf
+
+    @training_conf.setter
+    def training_conf(self, training_conf):
+        """
+        Set the training configuration.
+
+        If None is provided, attempts to load it
+        from the trained_model_path in the metrics configuration.
+        """
+        if training_conf is None:
+            try:
+                training_conf_path = self._get_training_conf_path_from_metrics()
+                logger.info(
+                    f"Loading training config from inferred path: {training_conf_path}"
+                )
+                self._training_conf = read_conf(training_conf_path)
+            except Exception as e:
+                logger.error(f"Failed to load training config: {e}")
+                raise
+        else:
+            self._training_conf = training_conf
+
+    @property
+    def plotting_conf(self):
+        """Get Plotting Conf.
+
+        A function to return the plotting configuration file name.
+
+        Returns
+        -------
+        str
+            Name of plotting configuration file
+        """
+        return self.metrics_conf.metrics.plotting_config
+
+    def _load_trained_psf_model(self):
+        trained_model_path = self._get_trained_model_path()
+        try:
+            model_subdir = self.metrics_conf.metrics.model_save_path
+            cycle = self.metrics_conf.metrics.saved_training_cycle
+        except AttributeError as e:
+            raise KeyError("Missing required model config fields.") from e
+
+        model_name = self.training_conf.training.model_params.model_name
+        id_name = self.training_conf.training.id_name
+
+        weights_path_pattern = os.path.join(
+            trained_model_path,
+            model_subdir,
+            (f"{model_subdir}*_{model_name}*{id_name}_cycle{cycle}*"),
+        )
+        return load_trained_psf_model(
+            self.training_conf,
+            self.data_conf,
+            weights_path_pattern,
+        )
+
+    def _get_training_conf_path_from_metrics(self):
+        """Get training config path from metrics config.
+
+        Retrieves the full path to the training config based on the metrics configuration.
+
+        Returns
+        -------
+        str
+            Full path to the training configuration file.
+
+        Raises
+        ------
+        KeyError
+            If 'trained_model_config' key is missing.
+        FileNotFoundError
+            If the file does not exist at the constructed path.
+        """
+        trained_model_path = self._get_trained_model_path()
+
+        try:
+            training_conf_filename = self._metrics_conf.metrics.trained_model_config
+        except AttributeError as e:
+            raise KeyError(
+                "Missing 'trained_model_config' key in metrics configuration."
+            ) from e
+
+        training_conf_path = os.path.join(
+            self._file_handler.get_config_dir(trained_model_path),
+            training_conf_filename,
+        )
+
+        if not os.path.exists(training_conf_path):
+            raise FileNotFoundError(
+                f"Training config file not found: {training_conf_path}"
+            )
+
+        return training_conf_path
+
+    def _get_trained_model_path(self):
+        """Get trained model path.
+
+        Determine the trained model path from either:
+
+        1. The metrics configuration file (i.e., for metrics-only runs after training), or
+        2. The runtime-generated file handler paths (i.e., for single runs that perform both training and evaluation).
+
+        Returns
+        -------
+        str
+            Path to the trained model directory.
+
+        Raises
+        ------
+        ConfigParameterError
+            If the path specified in the metrics config is invalid or missing.
+        """
+        trained_model_path = getattr(
+            self._metrics_conf.metrics, "trained_model_path", None
+        )
+
+        if trained_model_path:
+            if not os.path.isdir(trained_model_path):
+                raise ConfigParameterError(
+                    f"The trained model path provided in the metrics config is not a valid directory: {trained_model_path}"
+                )
+            logger.info(
+                f"Using trained model path from metrics config: {trained_model_path}"
+            )
+            return trained_model_path
+
+        # Fallback for single-run training + metrics evaluation mode
+        fallback_path = os.path.join(
+            self._file_handler.output_path,
+            self._file_handler.parent_output_dir,
+            self._file_handler.workdir,
+        )
+        logger.info(
+            f"Using fallback trained model path from runtime file handler: {fallback_path}"
+        )
+        return fallback_path
+
+    def _load_data_conf(self):
+        """Load Data Conf.
+
+        A method to load the data configuration file
+        and return an instance of DataConfigHandler class.
+
+        Returns
+        -------
+        An instance of the DataConfigHandler class.
+        """
+        try:
+            return DataConfigHandler(
+                os.path.join(
+                    self._file_handler.config_path,
+                    self.training_conf.training.data_config,
+                ),
+                self.training_conf.training.model_params,
+            )
+        except TypeError as e:
+            logger.exception(e)
+            raise ConfigParameterError("Data configuration loading error.")
+
+    def call_plot_config_handler_run(self, model_metrics):
+        """Make Metrics Plots.
+
+        A function to call the PlottingConfigHandler run
+        command to generate metrics plots.
+
+        Parameters
+        ----------
+        model_metrics: dict
+            A dictionary storing the metrics
+            output generated during evaluation
+            of the trained PSF model.
+
+        """
+        self._plotting_conf = os.path.join(
+            self._file_handler.config_path,
+            self.plotting_conf,
+        )
+
+        plots_config_handler = PlottingConfigHandler(
+            self._plotting_conf,
+            self._file_handler,
+        )
+
+        # Update metrics_confs dict with latest result
+        plots_config_handler.metrics_confs[self._file_handler.workdir] = (
+            self.metrics_conf
+        )
+
+        # Update metric results dict with latest result
+        plots_config_handler.list_of_metrics_dict[self._file_handler.workdir] = [
+            {
+                self.training_conf.training.model_params.model_name
+                + self.training_conf.training.id_name: [model_metrics]
+            }
+        ]
+
+        plots_config_handler.run()
+
+    def run(self):
+        """Run.
+
+        A function to run WaveDiff according to the
+        input configuration.
+
+        """
+        logger.info("Running metrics evaluation on trained PSF model...")
+
+        model_metrics = evaluate_model(
+            self.metrics_conf.metrics,
+            self.training_conf.training,
+            self.data_conf,
+            self.trained_psf_model,
+            self.metrics_dir,
+        )
+
+        if self.plotting_conf is not None:
+            self._file_handler.copy_conffile_to_output_dir(
+                self.metrics_conf.metrics.plotting_config
+            )
+            self.call_plot_config_handler_run(model_metrics)

--- a/src/wf_psf/plotting/plotting_config_handler.py
+++ b/src/wf_psf/plotting/plotting_config_handler.py
@@ -1,0 +1,206 @@
+"""PlottingConfigHandler.
+
+A module containing the PlottingConfigHandler class, which is responsible for managing the parameters of the plotting configuration file and running the
+plotting of the metrics of a trained PSF model
+
+:Authors: Jennifer Pollack <jennifer.pollack@cea.fr>
+"""
+
+import os
+import glob
+import numpy as np
+from typing import Any
+from wf_psf.utils.configs_handler import ConfigHandler, register_configclass
+from wf_psf.utils.read_config import read_conf
+from wf_psf.plotting.plots_interface import plot_metrics
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@register_configclass
+class PlottingConfigHandler(ConfigHandler):
+    """PlottingConfigHandler.
+
+    A class to handle plotting config
+    settings.
+
+    Parameters
+    ----------
+    ids: tuple
+        A tuple containing a string id for the Configuration Class
+    plotting_conf: str
+        Name of plotting configuration file
+    file_handler: obj
+        An instance of the FileIOHandler class
+
+    """
+
+    ids = ("plotting_conf",)
+
+    def __init__(self, plotting_conf, file_handler):
+        self.plotting_conf = read_conf(plotting_conf)
+        self.file_handler = file_handler
+        self.metrics_confs = {}
+        self.check_and_update_metrics_confs()
+        self.list_of_metrics_dict = self.make_dict_of_metrics()
+        self.plots_dir = self.file_handler.get_plots_dir(
+            self.file_handler._run_output_dir
+        )
+
+    def check_and_update_metrics_confs(self):
+        """Check and Update Metrics Confs.
+
+        A function to check if user provided inputs metrics
+        dir to add to metrics_confs dictionary.
+
+        """
+        if self.plotting_conf.plotting_params.metrics_dir:
+            self._update_metrics_confs()
+
+    def make_dict_of_metrics(self):
+        """Make dictionary of metrics.
+
+        A function to create a dictionary for each metrics per run.
+
+        Returns
+        -------
+        dict
+         A dictionary containing metrics or an empty dictionary.
+
+        """
+        if self.plotting_conf.plotting_params.metrics_dir:
+            return self.load_metrics_into_dict()
+        else:
+            return {}
+
+    def _update_metrics_confs(self):
+        """Update Metrics Configurations.
+
+        A method to update the metrics_confs dictionary
+        with each set of metrics configuration parameters
+        provided as input.
+
+        """
+        for wf_dir, metrics_conf in zip(
+            self.plotting_conf.plotting_params.metrics_dir,
+            self.plotting_conf.plotting_params.metrics_config,
+        ):
+            self.metrics_confs[wf_dir] = read_conf(
+                os.path.join(
+                    self.plotting_conf.plotting_params.metrics_output_path,
+                    self.file_handler.get_config_dir(wf_dir),
+                    metrics_conf,
+                )
+            )
+
+    def _metrics_run_id_name(self, wf_outdir, metrics_params):
+        """Get Metrics Run ID Name.
+
+        A function to generate run id name
+        for the metrics of a trained model
+
+        Parameters
+        ----------
+        wf_outdir: str
+            Name of the wf-psf run output directory
+        metrics_params: RecursiveNamespace Object
+            RecursiveNamespace object containing the metrics parameters used to evaluated the trained model.
+
+        Returns
+        -------
+        metrics_run_id_name: list
+            List containing the model name and id for each training run
+        """
+        try:
+            training_conf = read_conf(
+                os.path.join(
+                    metrics_params.metrics.trained_model_path,
+                    metrics_params.metrics.trained_model_config,
+                )
+            )
+            id_name = training_conf.training.id_name
+            model_name = training_conf.training.model_params.model_name
+            return [model_name + id_name]
+
+        except (TypeError, FileNotFoundError):
+            logger.info("Trained model path not provided...")
+            logger.info(
+                f"Trying to retrieve training config file from workdir: {wf_outdir}"
+            )
+
+            training_confs = [
+                read_conf(training_conf)
+                for training_conf in glob.glob(
+                    os.path.join(
+                        self.plotting_conf.plotting_params.metrics_output_path,
+                        self.file_handler.get_config_dir(wf_outdir),
+                        "training*",
+                    )
+                )
+            ]
+
+            run_ids = [
+                training_conf.training.model_params.model_name
+                + training_conf.training.id_name
+                for training_conf in training_confs
+            ]
+
+            return run_ids
+        except FileNotFoundError:
+            logger.exception("File not found.")
+
+    def load_metrics_into_dict(self):
+        """Load Metrics into Dictionary.
+
+        A method to load a metrics file of
+        a trained model from a previous run into a
+        dictionary.
+
+        Returns
+        -------
+        metrics_files_dict: dict
+            A dictionary containing all of the metrics from the loaded metrics files.
+
+        """
+        metrics_dict = {}
+
+        for k, v in self.metrics_confs.items():
+            run_id_names: list[Any] | None = self._metrics_run_id_name(k, v)
+
+            metrics_dict[k] = []
+            for run_id_name in run_id_names:  # pyright: ignore[reportOptionalIterable]
+                output_path = os.path.join(
+                    self.plotting_conf.plotting_params.metrics_output_path,
+                    k,
+                    "metrics",
+                    "metrics-" + run_id_name + ".npy",
+                )
+                logger.info(
+                    f"Attempting to read in trained model config file...{output_path}"
+                )
+                try:
+                    metrics_dict[k].append(
+                        {run_id_name: [np.load(output_path, allow_pickle=True)[()]]}
+                    )
+                except FileNotFoundError:
+                    logger.error(
+                        "The required file for the plots was not found. Please check your configs settings."
+                    )
+
+        return metrics_dict
+
+    def run(self):
+        """Run.
+
+        A function to run wave-diff according to the
+        input configuration.
+
+        """
+        logger.info("Generating metric plots...")
+        plot_metrics(
+            self.plotting_conf.plotting_params,
+            self.list_of_metrics_dict,
+            self.metrics_confs,
+            self.plots_dir,
+        )

--- a/src/wf_psf/tests/conftest.py
+++ b/src/wf_psf/tests/conftest.py
@@ -11,7 +11,7 @@ various wf_psf packages.
 import pytest
 from wf_psf.utils.read_config import RecursiveNamespace
 from wf_psf.training.train import TrainingParamsHandler
-from wf_psf.utils.configs_handler import DataConfigHandler
+from wf_psf.data.data_config_handler import DataConfigHandler
 from wf_psf.psf_models import psf_models
 from wf_psf.data.data_handler import DataHandler
 

--- a/src/wf_psf/tests/test_psf_models/psf_model_physical_polychromatic_test.py
+++ b/src/wf_psf/tests/test_psf_models/psf_model_physical_polychromatic_test.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 from wf_psf.psf_models.models.psf_model_physical_polychromatic import (
     TFPhysicalPolychromaticField,
 )
-from wf_psf.utils.configs_handler import DataConfigHandler
+from wf_psf.data.data_config_handler import DataConfigHandler
 
 
 @pytest.fixture

--- a/src/wf_psf/tests/test_training/training_config_handler_test.py
+++ b/src/wf_psf/tests/test_training/training_config_handler_test.py
@@ -1,0 +1,138 @@
+"""Unit tests for the TrainingConfigHandler class in training_config_handler.py"""
+
+import pytest
+from wf_psf.utils.configs_handler import ConfigHandler
+from wf_psf.training.training_config_handler import TrainingConfigHandler
+from wf_psf.utils.read_config import RecursiveNamespace
+from wf_psf.utils.io import FileIOHandler
+import os
+
+
+@pytest.fixture
+def mock_training_conf(mocker):
+    return RecursiveNamespace(
+        training=RecursiveNamespace(
+            id_name="_test_",
+            data_config="data_config.yaml",
+            load_data_on_init=True,
+            metrics_config=None,
+            model_params=RecursiveNamespace(
+                model_name="poly",
+                n_bins_lda=10,
+                param_hparams=RecursiveNamespace(
+                    random_seed=3877572,
+                ),
+                nonparam_hparams=RecursiveNamespace(
+                    d_max_nonparam=5,
+                ),
+            ),
+            training_hparams=RecursiveNamespace(batch_size=32),
+        ),
+    )
+
+
+@pytest.fixture
+def mock_data_conf(mocker):
+    # Create a mock object
+    data_conf = mocker.Mock()
+
+    # Set attributes on the mock object
+    data_conf.training_data = "value1"
+    data_conf.test_data = "value2"
+
+    return data_conf
+
+
+@pytest.fixture
+def mock_file_handler(mocker, tmp_path):
+    # Create a temporary directory
+    temp_dir = tmp_path / "temp_dir"
+    temp_dir.mkdir()
+
+    # Create a mock FileIOHandler instance
+    mock_fh = FileIOHandler(
+        output_path="/path/to/output",
+        config_path=str(temp_dir),
+    )
+
+    # Mock the methods of FileIOHandler as needed
+    mocker.patch.object(
+        mock_fh, "get_checkpoint_dir", return_value="/path/to/checkpoints"
+    )
+    mocker.patch.object(mock_fh, "get_optimizer_dir", return_value="/path/to/optimizer")
+    mocker.patch.object(mock_fh, "get_psf_model_dir", return_value="/path/to/psf_model")
+    mocker.patch.object(mock_fh, "copy_conffile_to_output_dir")
+
+    return mock_fh
+
+
+def test_training_handler_inherits_from_base():
+    """Test TrainingConfigHandler inherits from ConfigHandler."""
+    assert issubclass(TrainingConfigHandler, ConfigHandler)
+
+
+def test_training_handler_has_run():
+    """Test TrainingConfigHandler implements run()."""
+    assert hasattr(TrainingConfigHandler, "run")
+    assert callable(TrainingConfigHandler.run)
+
+
+def test_model_params_renamed(mock_training_conf):
+    """Test training_model_params renamed to model_params."""
+
+    # Should have model_params
+    assert hasattr(mock_training_conf.training, "model_params")
+
+    # Should NOT have old name
+    assert not hasattr(mock_training_conf.training, "training_model_params")
+
+
+def test_training_config_handler_init(mocker, mock_training_conf, mock_file_handler):
+    # Mock read_conf function
+    mocker.patch(
+        "wf_psf.training.training_config_handler.read_conf",
+        return_value=mock_training_conf,
+    )
+
+    # Mock data_conf instance
+    mock_data_conf = mocker.patch(
+        "wf_psf.training.training_config_handler.DataConfigHandler"
+    )
+
+    # Mock SimPSF instance
+    mock_simPSF_instance = mocker.Mock(name="SimPSFToolkit")
+    mocker.patch(
+        "wf_psf.psf_models.psf_models.simPSF", return_value=mock_simPSF_instance
+    )
+
+    # Initialize TrainingConfigHandler with the mock_file_handler
+    training_config_handler = TrainingConfigHandler(
+        "/path/to/training_config.yaml", mock_file_handler
+    )
+
+    # Assertions
+    mock_file_handler.copy_conffile_to_output_dir.assert_called_once_with(
+        training_config_handler.training_conf.training.data_config
+    )
+    mock_file_handler.get_checkpoint_dir.assert_called_once_with(
+        mock_file_handler._run_output_dir
+    )
+    mock_file_handler.get_optimizer_dir.assert_called_once_with(
+        mock_file_handler._run_output_dir
+    )
+    mock_file_handler.get_psf_model_dir.assert_called_once_with(
+        mock_file_handler._run_output_dir
+    )
+    assert training_config_handler.training_conf == mock_training_conf
+    assert training_config_handler.file_handler == mock_file_handler
+
+    mock_data_conf.assert_called_once_with(
+        os.path.join(
+            mock_file_handler.config_path,
+            training_config_handler.training_conf.training.data_config,
+        ),
+        training_config_handler.training_conf.training.model_params,
+        training_config_handler.training_conf.training.training_hparams.batch_size,
+        training_config_handler.training_conf.training.load_data_on_init,
+    )
+    assert training_config_handler.data_conf == mock_data_conf.return_value

--- a/src/wf_psf/tests/test_utils/configs_handler_test.py
+++ b/src/wf_psf/tests/test_utils/configs_handler_test.py
@@ -11,25 +11,34 @@ from wf_psf.data.data_handler import DataHandler
 from wf_psf.utils import configs_handler
 from wf_psf.utils.read_config import RecursiveNamespace
 from wf_psf.utils.io import FileIOHandler
-from wf_psf.utils.configs_handler import (
-    TrainingConfigHandler,
-    DataConfigHandler,
-)
-import os
+from wf_psf.data.data_config_handler import DataConfigHandler
+from wf_psf.training.training_config_handler import TrainingConfigHandler
+from wf_psf.metrics.metrics_config_handler import MetricsConfigHandler
+from wf_psf.plotting.plotting_config_handler import PlottingConfigHandler
+from wf_psf.utils.configs_handler import ConfigHandler, register_configclass
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
 
 
 @pytest.fixture
 def mock_data_read_conf(mocker):
     return mocker.patch(
-        "wf_psf.utils.configs_handler.read_conf",
+        "wf_psf.data.data_config_handler.read_conf",
         return_value=RecursiveNamespace(
             data=RecursiveNamespace(
+                data_type="simulation",
                 training=RecursiveNamespace(
-                    data_dir="/path/to/train_data", file="train_data.npy"
+                    data_dir="/path/to/train_data",
+                    file="train_data.npy",
+                    target_field="noisy_stars",
                 ),
                 test=RecursiveNamespace(
                     data_dir="/path/to/test_data",
                     file="test_data.npy",
+                    target_field="stars",
                 ),
             ),
         ),
@@ -61,57 +70,138 @@ def mock_training_conf(mocker):
 
 @pytest.fixture
 def mock_data_conf(mocker):
-    # Create a mock object
+    """Mock DataConfigHandler instance."""
     data_conf = mocker.Mock()
-
-    # Set attributes on the mock object
-    data_conf.training_data = "value1"
-    data_conf.test_data = "value2"
-
+    data_conf.training_data = mocker.Mock()
+    data_conf.test_data = mocker.Mock()
     return data_conf
 
 
-@configs_handler.register_configclass
-class RegisterConfigClass:
-    ids = ("test_conf",)
+@pytest.fixture
+def test_config_class():
+    """Fixture that registers and returns a test config class."""
 
-    def __init__(self, config_params, file_handler):
-        self.config_param = config_params
-        self.file_handler = file_handler
+    @register_configclass
+    class TestConfigClass(ConfigHandler):
+        ids = ("test_conf",)
 
+        def __init__(self, config_params, file_handler):
+            self.config_param = config_params
+            self.file_handler = file_handler
 
-def test_register_configclass():
-    assert configs_handler.CONFIG_CLASS["test_conf"] == RegisterConfigClass
+        def run(self):
+            pass
 
-
-def test_set_run_config():
-    config_class = configs_handler.set_run_config("test_conf")
-    assert config_class == RegisterConfigClass
-
-    config_class = configs_handler.set_run_config("training_conf")
-    assert config_class == configs_handler.TrainingConfigHandler
-
-    config_class = configs_handler.set_run_config("metrics_conf")
-    assert config_class == configs_handler.MetricsConfigHandler
-
-    config_class = configs_handler.set_run_config("plotting_conf")
-    assert config_class == configs_handler.PlottingConfigHandler
+    return TestConfigClass
 
 
-def test_get_run_config(path_to_tmp_output_dir, path_to_config_dir):
-    test_file_handler = FileIOHandler(path_to_tmp_output_dir, path_to_config_dir)
+# ============================================================================
+# Test Registry Pattern
+# ============================================================================
 
-    config_class = configs_handler.get_run_config(
-        "test_conf", "fake_config.yaml", test_file_handler
+
+class TestConfigRegistry:
+    """Tests for config handler registration and dispatch."""
+
+    def test_register_configclass(self, test_config_class):
+        """Test that @register_configclass adds handler to registry."""
+        assert configs_handler.CONFIG_CLASS["test_conf"] == test_config_class
+
+    def test_set_run_config_with_test_handler(self, test_config_class):
+        """Test set_run_config finds test handler by name."""
+        config_class = configs_handler.set_run_config("test_conf")
+        assert config_class == test_config_class
+
+    @pytest.mark.parametrize(
+        "config_name, expected_class",
+        [
+            ("training_conf", TrainingConfigHandler),
+            ("metrics_conf", MetricsConfigHandler),
+            ("plotting_conf", PlottingConfigHandler),
+        ],
+        ids=["training", "metrics", "plotting"],
     )
+    def test_set_run_config_with_real_handlers(self, config_name, expected_class):
+        """Test set_run_config finds real handlers by name."""
+        config_class = configs_handler.set_run_config(config_name)
+        assert config_class == expected_class
 
-    assert type(config_class) is RegisterConfigClass
+    def test_set_run_config_invalid_name_raises_exception(self):
+        """Test set_run_config raises for unrecognized config name."""
+        with pytest.raises(Exception):  # Could be KeyError or IndexError
+            configs_handler.set_run_config("nonexistent_conf")
+
+    def test_get_run_config_instantiates(
+        self, test_config_class, path_to_tmp_output_dir, path_to_config_dir
+    ):
+        """Test get_run_config returns instance of correct handler."""
+        test_file_handler = FileIOHandler(path_to_tmp_output_dir, path_to_config_dir)
+
+        config_instance = configs_handler.get_run_config(
+            "test_conf", "fake_config.yaml", test_file_handler
+        )
+
+        assert isinstance(config_instance, test_config_class)
+        assert config_instance.config_param == "fake_config.yaml"
+        assert config_instance.file_handler == test_file_handler
 
 
-@pytest.mark.skip(
-    reason="DataConfigHandler refactored - no longer creates DataHandler in __init__"
-)
+# ============================================================================
+# Test ConfigHandler ABC
+# ============================================================================
+
+
+class TestConfigHandlerABC:
+    """Tests for ConfigHandler abstract base class."""
+
+    def test_config_handler_requires_run_method(self):
+        """Test that handlers must implement run()."""
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+
+            @register_configclass
+            class InvalidHandler(ConfigHandler):
+                ids = ("invalid_conf",)
+                # Missing run() method!
+
+            InvalidHandler()
+
+    def test_config_handler_requires_ids(self):
+        """Test that handlers must define ids attribute."""
+
+        class NoIdsHandler(ConfigHandler):
+            def run(self):
+                pass
+
+        # Should fail when trying to register (no ids attribute)
+        with pytest.raises(AttributeError):
+            register_configclass(NoIdsHandler)
+
+    def test_all_registered_handlers_inherit_from_base(self):
+        """Test all registered handlers inherit from ConfigHandler."""
+        for handler_class in configs_handler.CONFIG_CLASS.values():
+            assert issubclass(handler_class, ConfigHandler)
+
+    def test_all_registered_handlers_have_run(self):
+        """Test all registered handlers implement run()."""
+        for handler_class in configs_handler.CONFIG_CLASS.values():
+            assert hasattr(handler_class, "run")
+            assert callable(handler_class.run)
+
+
+# ============================================================================
+# Test DataConfigHandler (moved from here, should be in test_data_config_handler.py)
+# ============================================================================
+
+
+@pytest.mark.skip(reason="Skipped - deprecated DataHandler pending removal")
 def test_data_config_handler_init(mock_training_conf, mock_data_read_conf, mocker):
+    """
+    Test DataConfigHandler initialization.
+
+    NOTE: This test is skipped because it tests deprecated DataHandler
+    behavior. Once DataHandler is removed, this test should be updated
+    or moved to test_data_config_handler.py with proper mocking.
+    """
     # Mock read_conf function
     mock_data_read_conf()
 
@@ -160,88 +250,51 @@ def test_data_config_handler_init(mock_training_conf, mock_data_read_conf, mocke
     )
 
 
-def test_training_config_handler_init(mocker, mock_training_conf, mock_file_handler):
-    # Mock read_conf function
-    mocker.patch(
-        "wf_psf.utils.configs_handler.read_conf", return_value=mock_training_conf
-    )
-
-    # Mock data_conf instance
-    mock_data_conf = mocker.patch("wf_psf.utils.configs_handler.DataConfigHandler")
-
-    # Mock SimPSF instance
-    mock_simPSF_instance = mocker.Mock(name="SimPSFToolkit")
-    mocker.patch(
-        "wf_psf.psf_models.psf_models.simPSF", return_value=mock_simPSF_instance
-    )
-
-    # Initialize TrainingConfigHandler with the mock_file_handler
-    training_config_handler = TrainingConfigHandler(
-        "/path/to/training_config.yaml", mock_file_handler
-    )
-
-    # Assertions
-    mock_file_handler.copy_conffile_to_output_dir.assert_called_once_with(
-        training_config_handler.training_conf.training.data_config
-    )
-    mock_file_handler.get_checkpoint_dir.assert_called_once_with(
-        mock_file_handler._run_output_dir
-    )
-    mock_file_handler.get_optimizer_dir.assert_called_once_with(
-        mock_file_handler._run_output_dir
-    )
-    mock_file_handler.get_psf_model_dir.assert_called_once_with(
-        mock_file_handler._run_output_dir
-    )
-    assert training_config_handler.training_conf == mock_training_conf
-    assert training_config_handler.file_handler == mock_file_handler
-
-    mock_data_conf.assert_called_once_with(
-        os.path.join(
-            mock_file_handler.config_path,
-            training_config_handler.training_conf.training.data_config,
-        ),
-        training_config_handler.training_conf.training.model_params,
-        training_config_handler.training_conf.training.training_hparams.batch_size,
-        training_config_handler.training_conf.training.load_data_on_init,
-    )
-    assert training_config_handler.data_conf == mock_data_conf.return_value
+# ============================================================================
+# Test TrainingConfigHandler (should be in test_training_config_handler.py)
+# ============================================================================
 
 
-def test_run_method_calls_train_with_correct_arguments(
-    mocker, mock_training_conf, mock_data_conf
-):
-    # Patch the TrainingConfigHandler.__init__() method
-    mocker.patch(
-        "wf_psf.utils.configs_handler.TrainingConfigHandler.__init__", return_value=None
-    )
-    mock_th = TrainingConfigHandler(None, None)
-    # Set attributes of the mock_th
-    mock_th.training_conf = mock_training_conf
-    mock_th.data_conf = mock_data_conf
-    mock_th.data_conf.training_data = mock_data_conf.training_data
-    mock_th.data_conf.test_data = mock_data_conf.test_data
-    mock_th.checkpoint_dir = "/mock/checkpoint/dir"
-    mock_th.optimizer_dir = "/mock/optimizer/dir"
-    mock_th.psf_model_dir = "/mock/psf/model/dir"
+class TestTrainingConfigHandler:
+    """Tests for TrainingConfigHandler."""
 
-    # Patch the train.train() function
-    mock_train_function = mocker.patch("wf_psf.training.train.train")
+    def test_run_method_calls_train_with_correct_arguments(
+        self, mocker, mock_training_conf, mock_data_conf
+    ):
+        """Test that run() calls train.train() with correct arguments."""
+        # Patch the TrainingConfigHandler.__init__() method
+        mocker.patch(
+            "wf_psf.training.training_config_handler.TrainingConfigHandler.__init__",
+            return_value=None,
+        )
+        mock_th = TrainingConfigHandler(None, None)
 
-    # Create a spy for the run method
-    spy = mocker.spy(mock_th, "run")
+        # Set attributes of the mock_th
+        mock_th.training_conf = mock_training_conf
+        mock_th.data_conf = mock_data_conf
+        mock_th.data_conf.training_data = mock_data_conf.training_data
+        mock_th.data_conf.test_data = mock_data_conf.test_data
+        mock_th.checkpoint_dir = "/mock/checkpoint/dir"
+        mock_th.optimizer_dir = "/mock/optimizer/dir"
+        mock_th.psf_model_dir = "/mock/psf/model/dir"
 
-    # Call the run method
-    mock_th.run()
+        # Patch the train.train() function
+        mock_train_function = mocker.patch("wf_psf.training.train.train")
 
-    # Assert that run() is called once
-    spy.assert_called_once()
+        # Create a spy for the run method
+        spy = mocker.spy(mock_th, "run")
 
-    # Assert that train.train() is called with the correct arguments
-    mock_train_function.assert_called_once_with(
-        mock_th.training_conf.training,
-        mock_th.data_conf,
-        mock_th.checkpoint_dir,
-        mock_th.optimizer_dir,
-        mock_th.psf_model_dir,
-    )
+        # Call the run method
+        mock_th.run()
+
+        # Assert that run() is called once
+        spy.assert_called_once()
+
+        # Assert that train.train() is called with the correct arguments
+        mock_train_function.assert_called_once_with(
+            mock_th.training_conf.training,
+            mock_th.data_conf,
+            mock_th.checkpoint_dir,
+            mock_th.optimizer_dir,
+            mock_th.psf_model_dir,
+        )

--- a/src/wf_psf/training/training_config_handler.py
+++ b/src/wf_psf/training/training_config_handler.py
@@ -1,0 +1,95 @@
+"""Training Config Handler.
+
+A module which provides a class to manage the parameters of the training config file.
+
+:Authors: Jennifer Pollack <jennifer.pollack@cea.fr>
+
+"""
+
+import os
+from wf_psf.utils.configs_handler import ConfigHandler, register_configclass
+from wf_psf.data.data_config_handler import DataConfigHandler
+from wf_psf.utils.read_config import read_conf
+from wf_psf.training import train
+from wf_psf.metrics.metrics_config_handler import MetricsConfigHandler
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+@register_configclass
+class TrainingConfigHandler(ConfigHandler):
+    """TrainingConfigHandler.
+
+    A class to handle training configuration
+    parameters.
+
+    Parameters
+    ----------
+    ids: tuple
+        A tuple containing a string id for the Configuration Class
+    training_conf: str
+        Path of the training configuration file
+    file_handler: object
+        A instance of the FileIOHandler class
+
+    """
+
+    ids = ("training_conf",)
+
+    def __init__(self, training_conf, file_handler):
+        self.training_conf = read_conf(training_conf)
+        self.file_handler = file_handler
+        self.data_conf = DataConfigHandler(
+            os.path.join(
+                file_handler.config_path, self.training_conf.training.data_config
+            ),
+            self.training_conf.training.model_params,
+            self.training_conf.training.training_hparams.batch_size,
+            self.training_conf.training.load_data_on_init,
+        )
+        self.data_conf.run_type = "training"
+        self.file_handler.copy_conffile_to_output_dir(
+            self.training_conf.training.data_config
+        )
+        self.checkpoint_dir = file_handler.get_checkpoint_dir(
+            self.file_handler._run_output_dir
+        )
+        self.optimizer_dir = file_handler.get_optimizer_dir(
+            self.file_handler._run_output_dir
+        )
+        self.psf_model_dir = file_handler.get_psf_model_dir(
+            self.file_handler._run_output_dir
+        )
+
+    def run(self):
+        """Run.
+
+        A function to run wavediff according to the
+        input configuration.
+
+        """
+        train.train(
+            self.training_conf.training,
+            self.data_conf,
+            self.checkpoint_dir,
+            self.optimizer_dir,
+            self.psf_model_dir,
+        )
+
+        if self.training_conf.training.metrics_config is not None:
+            self.file_handler.copy_conffile_to_output_dir(
+                self.training_conf.training.metrics_config
+            )
+
+            metrics = MetricsConfigHandler(
+                os.path.join(
+                    self.file_handler.config_path,
+                    self.training_conf.training.metrics_config,
+                ),
+                self.file_handler,
+                self.training_conf,
+            )
+
+            metrics.run()

--- a/src/wf_psf/utils/configs_handler.py
+++ b/src/wf_psf/utils/configs_handler.py
@@ -1,29 +1,33 @@
-"""Configs_Handler.
+"""Configs_Handler Registry.
 
-A module which provides general utility methods
-to manage the parameters of the config files
+Provides runtime dispatch for config handlers based on config file names.
 
 :Authors: Jennifer Pollack <jennifer.pollack@cea.fr>
 
 """
 
-import numpy as np
+from abc import ABC, abstractmethod
 import logging
-import os
 import re
-import glob
-from wf_psf.data.data_handler import DataHandlerFactory
-from wf_psf.metrics.metrics_interface import evaluate_model
-from wf_psf.plotting.plots_interface import plot_metrics
-from wf_psf.psf_models import psf_models
-from wf_psf.psf_models.psf_model_loader import load_trained_psf_model
-from wf_psf.training import train
-from wf_psf.utils.read_config import read_conf
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 
 logger = logging.getLogger(__name__)
 
 CONFIG_CLASS = {}
+
+
+class ConfigHandler(ABC):
+    """Abstract base class for all config handlers."""
+
+    ids: tuple[str, ...]
+
+    @abstractmethod
+    def run(self):
+        """Execute the configured task."""
+        pass
 
 
 def register_configclass(config_class):
@@ -109,588 +113,50 @@ class ConfigParameterError(Exception):
         super().__init__(self.message)
 
 
-class DataConfigHandler:
-    """DataConfigHandler.
-
-    A class to handle data configuration
-    parameters.
-
-    Parameters
-    ----------
-    data_conf : str
-        Path of the data configuration file
-    training_model_params : Recursive Namespace object
-        Recursive Namespace object containing the training model parameters
-    batch_size : int
-       Training hyperparameter used for batched pre-processing of data.
-
+# Lazy imports for backward compatibility (avoids circular imports)
+def __getattr__(name):
     """
+    Lazy import handler for backward compatibility.
 
-    def __init__(self, data_conf, training_model_params, batch_size=16, load_data=True):
-        try:
-            self.data_conf = read_conf(data_conf)
-        except (FileNotFoundError, TypeError) as e:
-            logger.exception(e)
-            exit()
+    Allows old code like:
+        from wf_psf.utils.configs_handler import TrainingConfigHandler
 
-        self.simPSF = psf_models.simPSF(training_model_params)
-
-        # Extract sub-configs early
-        train_params = self.data_conf.data.training
-        test_params = self.data_conf.data.test
-
-        self.training_data = DataHandlerFactory.create_from_config(
-            data_params=train_params,
-            simPSF=self.simPSF,
-            n_bins_lambda=training_model_params.n_bins_lda,
-            dataset_type="training",
-            load_data=load_data,
-        )
-        self.test_data = DataHandlerFactory.create_from_config(
-            data_params=test_params,
-            simPSF=self.simPSF,
-            n_bins_lambda=training_model_params.n_bins_lda,
-            dataset_type="test",
-            load_data=load_data,
-        )
-
-        self.batch_size = batch_size
-
-
-@register_configclass
-class TrainingConfigHandler:
-    """TrainingConfigHandler.
-
-    A class to handle training configuration
-    parameters.
-
-    Parameters
-    ----------
-    ids: tuple
-        A tuple containing a string id for the Configuration Class
-    training_conf: str
-        Path of the training configuration file
-    file_handler: object
-        A instance of the FileIOHandler class
-
+    to continue working without circular imports.
     """
-
-    ids = ("training_conf",)
-
-    def __init__(self, training_conf, file_handler):
-        self.training_conf = read_conf(training_conf)
-        self.file_handler = file_handler
-        self.data_conf = DataConfigHandler(
-            os.path.join(
-                file_handler.config_path, self.training_conf.training.data_config
-            ),
-            self.training_conf.training.model_params,
-            self.training_conf.training.training_hparams.batch_size,
-            self.training_conf.training.load_data_on_init,
-        )
-
-        self.data_conf.run_type = "training"
-        self.file_handler.copy_conffile_to_output_dir(
-            self.training_conf.training.data_config
-        )
-        self.checkpoint_dir = file_handler.get_checkpoint_dir(
-            self.file_handler._run_output_dir
-        )
-        self.optimizer_dir = file_handler.get_optimizer_dir(
-            self.file_handler._run_output_dir
-        )
-        self.psf_model_dir = file_handler.get_psf_model_dir(
-            self.file_handler._run_output_dir
-        )
-
-    def run(self):
-        """Run.
-
-        A function to run wavediff according to the
-        input configuration.
-
-        """
-        train.train(
-            self.training_conf.training,
-            self.data_conf,
-            self.checkpoint_dir,
-            self.optimizer_dir,
-            self.psf_model_dir,
-        )
-
-        if self.training_conf.training.metrics_config is not None:
-            self.file_handler.copy_conffile_to_output_dir(
-                self.training_conf.training.metrics_config
-            )
-
-            metrics = MetricsConfigHandler(
-                os.path.join(
-                    self.file_handler.config_path,
-                    self.training_conf.training.metrics_config,
-                ),
-                self.file_handler,
-                self.training_conf,
-            )
-
-            metrics.run()
-
-
-@register_configclass
-class MetricsConfigHandler:
-    """MetricsConfigHandler.
-
-    A class to handle metrics configuation
-    parameters.
-
-    Parameters
-    ----------
-    ids: tuple
-        A tuple containing a string id for the Configuration Class
-    metrics_conf: str
-        Path to the metrics configuration file
-    file_handler: object
-        An instance of the FileIOHandler
-    training_conf: RecursiveNamespace object
-        RecursiveNamespace object containing the training configuration parameters
-
-
-    """
-
-    ids = ("metrics_conf",)
-
-    def __init__(self, metrics_conf, file_handler, training_conf=None):
-        self._metrics_conf = read_conf(metrics_conf)
-        self._file_handler = file_handler
-        self.training_conf = training_conf
-        self.data_conf = self._load_data_conf()
-        self.data_conf.run_type = "metrics"
-        self.metrics_dir = self._file_handler.get_metrics_dir(
-            self._file_handler._run_output_dir
-        )
-        self.trained_psf_model = self._load_trained_psf_model()
-
-    @property
-    def metrics_conf(self):
-        """Get Metrics Conf.
-
-        A function to return the metrics configuration file name.
-
-        Returns
-        -------
-        RecursiveNamespace
-            An instance of the metrics configuration file.
-        """
-        return self._metrics_conf
-
-    @property
-    def training_conf(self):
-        """Returns the loaded training configuration."""
-        return self._training_conf
-
-    @training_conf.setter
-    def training_conf(self, training_conf):
-        """
-        Set the training configuration.
-
-        If None is provided, attempts to load it
-        from the trained_model_path in the metrics configuration.
-        """
-        if training_conf is None:
-            try:
-                training_conf_path = self._get_training_conf_path_from_metrics()
-                logger.info(
-                    f"Loading training config from inferred path: {training_conf_path}"
-                )
-                self._training_conf = read_conf(training_conf_path)
-            except Exception as e:
-                logger.error(f"Failed to load training config: {e}")
-                raise
-        else:
-            self._training_conf = training_conf
-
-    @property
-    def plotting_conf(self):
-        """Get Plotting Conf.
-
-        A function to return the plotting configuration file name.
-
-        Returns
-        -------
-        str
-            Name of plotting configuration file
-        """
-        return self.metrics_conf.metrics.plotting_config
-
-    def _load_trained_psf_model(self):
-        trained_model_path = self._get_trained_model_path()
-        try:
-            model_subdir = self.metrics_conf.metrics.model_save_path
-            cycle = self.metrics_conf.metrics.saved_training_cycle
-        except AttributeError as e:
-            raise KeyError("Missing required model config fields.") from e
-
-        model_name = self.training_conf.training.model_params.model_name
-        id_name = self.training_conf.training.id_name
-
-        weights_path_pattern = os.path.join(
-            trained_model_path,
-            model_subdir,
-            (f"{model_subdir}*_{model_name}*{id_name}_cycle{cycle}*"),
-        )
-        return load_trained_psf_model(
-            self.training_conf,
-            self.data_conf,
-            weights_path_pattern,
-        )
-
-    def _get_training_conf_path_from_metrics(self):
-        """
-        Retrieve the full path to the training config based on the metrics configuration.
-
-        Returns
-        -------
-        str
-            Full path to the training configuration file.
-
-        Raises
-        ------
-        KeyError
-            If 'trained_model_config' key is missing.
-        FileNotFoundError
-            If the file does not exist at the constructed path.
-        """
-        trained_model_path = self._get_trained_model_path()
-
-        try:
-            training_conf_filename = self._metrics_conf.metrics.trained_model_config
-        except AttributeError as e:
-            raise KeyError(
-                "Missing 'trained_model_config' key in metrics configuration."
-            ) from e
-
-        training_conf_path = os.path.join(
-            self._file_handler.get_config_dir(trained_model_path),
-            training_conf_filename,
-        )
-
-        if not os.path.exists(training_conf_path):
-            raise FileNotFoundError(
-                f"Training config file not found: {training_conf_path}"
-            )
-
-        return training_conf_path
-
-    def _get_trained_model_path(self):
-        """Get Trained Model Path.
-
-        Determine the trained model path from either:
-
-        1. The metrics configuration file (i.e., for metrics-only runs after training), or
-        2. The runtime-generated file handler paths (i.e., for single runs that perform both training and evaluation).
-
-        Returns
-        -------
-        str
-            Path to the trained model directory.
-
-        Raises
-        ------
-        ConfigParameterError
-            If the path specified in the metrics config is invalid or missing.
-        """
-        trained_model_path = getattr(
-            self._metrics_conf.metrics, "trained_model_path", None
-        )
-
-        if trained_model_path:
-            if not os.path.isdir(trained_model_path):
-                raise ConfigParameterError(
-                    f"The trained model path provided in the metrics config is not a valid directory: {trained_model_path}"
-                )
-            logger.info(
-                f"Using trained model path from metrics config: {trained_model_path}"
-            )
-            return trained_model_path
-
-        # Fallback for single-run training + metrics evaluation mode
-        fallback_path = os.path.join(
-            self._file_handler.output_path,
-            self._file_handler.parent_output_dir,
-            self._file_handler.workdir,
-        )
-        logger.info(
-            f"Using fallback trained model path from runtime file handler: {fallback_path}"
-        )
-        return fallback_path
-
-    def _load_data_conf(self):
-        """Load Data Conf.
-
-        A method to load the data configuration file
-        and return an instance of DataConfigHandler class.
-
-        Returns
-        -------
-        An instance of the DataConfigHandler class.
-        """
-        try:
-            return DataConfigHandler(
-                os.path.join(
-                    self._file_handler.config_path,
-                    self.training_conf.training.data_config,
-                ),
-                self.training_conf.training.model_params,
-            )
-        except TypeError as e:
-            logger.exception(e)
-            raise ConfigParameterError("Data configuration loading error.")
-
-    def call_plot_config_handler_run(self, model_metrics):
-        """Make Metrics Plots.
-
-        A function to call the PlottingConfigHandler run
-        command to generate metrics plots.
-
-        Parameters
-        ----------
-        model_metrics: dict
-            A dictionary storing the metrics
-            output generated during evaluation
-            of the trained PSF model.
-
-        """
-        self._plotting_conf = os.path.join(
-            self._file_handler.config_path,
-            self.plotting_conf,
-        )
-
-        plots_config_handler = PlottingConfigHandler(
-            self._plotting_conf,
-            self._file_handler,
-        )
-
-        # Update metrics_confs dict with latest result
-        plots_config_handler.metrics_confs[self._file_handler.workdir] = (
-            self.metrics_conf
-        )
-
-        # Update metric results dict with latest result
-        plots_config_handler.list_of_metrics_dict[self._file_handler.workdir] = [
-            {
-                self.training_conf.training.model_params.model_name
-                + self.training_conf.training.id_name: [model_metrics]
-            }
-        ]
-
-        plots_config_handler.run()
-
-    def run(self):
-        """Run.
-
-        A function to run WaveDiff according to the
-        input configuration.
-
-        """
-        logger.info("Running metrics evaluation on trained PSF model...")
-
-        model_metrics = evaluate_model(
-            self.metrics_conf.metrics,
-            self.training_conf.training,
-            self.data_conf,
-            self.trained_psf_model,
-            self.metrics_dir,
-        )
-
-        if self.plotting_conf is not None:
-            self._file_handler.copy_conffile_to_output_dir(
-                self.metrics_conf.metrics.plotting_config
-            )
-            self.call_plot_config_handler_run(model_metrics)
-
-
-@register_configclass
-class PlottingConfigHandler:
-    """PlottingConfigHandler.
-
-    A class to handle plotting config
-    settings.
-
-    Parameters
-    ----------
-    ids: tuple
-        A tuple containing a string id for the Configuration Class
-    plotting_conf: str
-        Name of plotting configuration file
-    file_handler: obj
-        An instance of the FileIOHandler class
-
-    """
-
-    ids = ("plotting_conf",)
-
-    def __init__(self, plotting_conf, file_handler):
-        self.plotting_conf = read_conf(plotting_conf)
-        self.file_handler = file_handler
-        self.metrics_confs = {}
-        self.check_and_update_metrics_confs()
-        self.list_of_metrics_dict = self.make_dict_of_metrics()
-        self.plots_dir = self.file_handler.get_plots_dir(
-            self.file_handler._run_output_dir
-        )
-
-    def check_and_update_metrics_confs(self):
-        """Check and Update Metrics Confs.
-
-        A function to check if user provided inputs metrics
-        dir to add to metrics_confs dictionary.
-
-        """
-        if self.plotting_conf.plotting_params.metrics_dir:
-            self._update_metrics_confs()
-
-    def make_dict_of_metrics(self):
-        """Make dictionary of metrics.
-
-        A function to create a dictionary for each metrics per run.
-
-        Returns
-        -------
-        dict
-         A dictionary containing metrics or an empty dictionary.
-
-        """
-        if self.plotting_conf.plotting_params.metrics_dir:
-            return self.load_metrics_into_dict()
-        else:
-            return {}
-
-    def _update_metrics_confs(self):
-        """Update Metrics Configurations.
-
-        A method to update the metrics_confs dictionary
-        with each set of metrics configuration parameters
-        provided as input.
-
-        """
-        for wf_dir, metrics_conf in zip(
-            self.plotting_conf.plotting_params.metrics_dir,
-            self.plotting_conf.plotting_params.metrics_config,
-        ):
-            self.metrics_confs[wf_dir] = read_conf(
-                os.path.join(
-                    self.plotting_conf.plotting_params.metrics_output_path,
-                    self.file_handler.get_config_dir(wf_dir),
-                    metrics_conf,
-                )
-            )
-
-    def _metrics_run_id_name(self, wf_outdir, metrics_params):
-        """Get Metrics Run ID Name.
-
-        A function to generate run id name
-        for the metrics of a trained model
-
-        Parameters
-        ----------
-        wf_outdir: str
-            Name of the wf-psf run output directory
-        metrics_params: RecursiveNamespace Object
-            RecursiveNamespace object containing the metrics parameters used to evaluated the trained model.
-
-        Returns
-        -------
-        metrics_run_id_name: list
-            List containing the model name and id for each training run
-        """
-        try:
-            training_conf = read_conf(
-                os.path.join(
-                    metrics_params.metrics.trained_model_path,
-                    metrics_params.metrics.trained_model_config,
-                )
-            )
-            id_name = training_conf.training.id_name
-            model_name = training_conf.training.model_params.model_name
-            return [model_name + id_name]
-
-        except (TypeError, FileNotFoundError):
-            logger.info("Trained model path not provided...")
-            logger.info(
-                f"Trying to retrieve training config file from workdir: {wf_outdir}"
-            )
-
-            training_confs = [
-                read_conf(training_conf)
-                for training_conf in glob.glob(
-                    os.path.join(
-                        self.plotting_conf.plotting_params.metrics_output_path,
-                        self.file_handler.get_config_dir(wf_outdir),
-                        "training*",
-                    )
-                )
-            ]
-
-            run_ids = [
-                training_conf.training.model_params.model_name
-                + training_conf.training.id_name
-                for training_conf in training_confs
-            ]
-
-            return run_ids
-        except FileNotFoundError:
-            logger.exception("File not found.")
-
-    def load_metrics_into_dict(self):
-        """Load Metrics into Dictionary.
-
-        A method to load a metrics file of
-        a trained model from a previous run into a
-        dictionary.
-
-        Returns
-        -------
-        metrics_files_dict: dict
-            A dictionary containing all of the metrics from the loaded metrics files.
-
-        """
-        metrics_dict = {}
-
-        for k, v in self.metrics_confs.items():
-            run_id_names = self._metrics_run_id_name(k, v)
-
-            metrics_dict[k] = []
-            for run_id_name in run_id_names:
-                output_path = os.path.join(
-                    self.plotting_conf.plotting_params.metrics_output_path,
-                    k,
-                    "metrics",
-                    "metrics-" + run_id_name + ".npy",
-                )
-                logger.info(
-                    f"Attempting to read in trained model config file...{output_path}"
-                )
-                try:
-                    metrics_dict[k].append(
-                        {run_id_name: [np.load(output_path, allow_pickle=True)[()]]}
-                    )
-                except FileNotFoundError:
-                    logger.error(
-                        "The required file for the plots was not found. Please check your configs settings."
-                    )
-
-        return metrics_dict
-
-    def run(self):
-        """Run.
-
-        A function to run wave-diff according to the
-        input configuration.
-
-        """
-        logger.info("Generating metric plots...")
-        plot_metrics(
-            self.plotting_conf.plotting_params,
-            self.list_of_metrics_dict,
-            self.metrics_confs,
-            self.plots_dir,
-        )
+    _HANDLER_MAP = {
+        "TrainingConfigHandler": "wf_psf.training.training_config_handler",
+        "MetricsConfigHandler": "wf_psf.metrics.metrics_config_handler",
+        "PlottingConfigHandler": "wf_psf.plotting.plotting_config_handler",
+        "DataConfigHandler": "wf_psf.data.data_config_handler",
+    }
+
+    if name in _HANDLER_MAP:
+        import importlib
+
+        module = importlib.import_module(_HANDLER_MAP[name])
+        return getattr(module, name)
+
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+# Type checking imports (not executed at runtime)
+if TYPE_CHECKING:
+    from wf_psf.training.training_config_handler import TrainingConfigHandler
+    from wf_psf.metrics.metrics_config_handler import MetricsConfigHandler
+    from wf_psf.plotting.plotting_config_handler import PlottingConfigHandler
+    from wf_psf.data.data_config_handler import DataConfigHandler
+
+
+__all__ = [
+    "ConfigHandler",
+    "register_configclass",
+    "set_run_config",
+    "get_run_config",
+    "ConfigParameterError",
+    "CONFIG_CLASS",
+    # Handlers available via lazy import
+    "TrainingConfigHandler",
+    "MetricsConfigHandler",
+    "PlottingConfigHandler",
+    "DataConfigHandler",
+]


### PR DESCRIPTION

## Summary

Move config handlers from single monolithic file into their respective task packages while maintaining backward compatibility via lazy imports. Add ConfigHandler abstract base class to enforce consistent interface.

## What’s changed

Changes:
- Add `ConfigHandler ABC` requiring `run()` method and ids attribute
- Move config handlers to task packages:
  * `DataConfigHandler` → `data/data_config_handler.py`
  * `TrainingConfigHandler` → `training/training_config_handler.py`
  * `MetricsConfigHandler` → metrics/metrics_config_handler.py
  * `PlottingConfigHandler` → plotting/plotting_config_handler.py
- Refactor configs_handler.py to registry-only (ABC + helper functions)
- Add lazy imports via __getattr__ for backward compatibility
- Register handlers automatically in wf_psf/__init__.py

Backward compatibility:
- Old imports still work via `__getattr__` lazy loading
- Registry functions (`get_run_config`, `set_run_config`) unchanged
- `TYPE_CHECKING` guard satisfies static analysis tools

Tests:
- Add `TestConfigHandlerABC` for ABC enforcement
- Reorganize into `TestConfigRegistry` and `TestTrainingConfigHandler` classes
- Add tests for all registered handlers inheriting from `ConfigHandler`
- Update import paths throughout test suite


## How to test / verify

Repeatability tests of training and metrics pass.


## Scope

> Indicate the type of PR:

- [ ] Feature  
- [ ] Bug fix  
- [ ] Hotfix  
- [ ] Documentation / process change  
- [X] Internal / refactor  
- [ ] Release

> Optionally, note if this PR is part of a larger milestone or set of related PRs.


## Changelog

> Did this PR introduce user-visible changes?  
> If yes, a **Scriv changelog fragment** must be added and committed.

- [X] Changelog fragment added (if applicable)


## Reviewer Checklist

> Reviewers should confirm the following before approving and merging:

- [x] The PR targets the correct base branch (`develop`, or `main` for release PRs)
- [x] The PR is assigned to the developer
- [x] Appropriate labels are applied
- [x] The PR is included in relevant projects and/or milestones
- [x] Description clearly explains what has changed
- [x] Issue references included, if applicable
- [x] Code and documentation adhere to current standards (`ruff`)
- [x] Documentation updates included, if relevant
- [x] CI tests are passing
- [x] All reviewer comments have been addressed


## Next Steps / Notes (if applicable)

> Any follow-up actions, known issues, or reminders for maintainers.

