### PR TITLE
Bugfix/metrics config handler training conf namespace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ maintainers = [
 
 description = 'A software framework to perform Differentiable wavefront-based PSF modelling.'
 dependencies = [
-    "numpy>=1.18,<1.24",
+    "numpy<2.0.0,>=1.23.5",
     "scipy",
-    "tensorflow==2.11.0",
+    "tensorflow==2.15.0",
     "tensorflow-estimator",
     "zernike",
     "opencv-python",

--- a/src/wf_psf/metrics/metrics_config_handler.py
+++ b/src/wf_psf/metrics/metrics_config_handler.py
@@ -301,7 +301,7 @@ class MetricsConfigHandler(ConfigHandler):
 
         model_metrics = evaluate_model(
             self.metrics_conf.metrics,
-            self.training_conf.training,
+            self.training_conf,
             self.data_adapter,
             self.simPSF,
             self.trained_psf_model,


### PR DESCRIPTION
## Summary

This PR fixes a small namespace bug in the `metrics_config_handler.py` identified when running the `develop` branch on simulated validation data. 

```
2026-04-10 21:44:03,908 - wf_psf.metrics.metrics_config_handler - INFO - Running metrics evaluation on trained PSF model...
2026-04-10 21:44:03,908 - wf_psf.data.data_adapter - INFO - Split data already exists; reusing existing train/test split (idempotent call).
2026-04-10 21:44:07,573 - wavediff - ERROR - Check your config file /sps/euclid/Users/jpollack/Euclid-PSF/validation/vxx/v1xx/v1_1_0/configs.yaml for errors. Error Msg: 'RecursiveNamespace' object has no attribute 'training'.
```
 The `training` attribute  


## What’s changed

- Updated Tensorflow to 2.15.0 and Numpy to >=1.23.5, <2.0.0 in `pyproject.toml`
- Fixed namespace error involving passing the training configuration object to `evaluate_model` in `metrics_config_handler.py`


## How to test / verify

> Outline steps for reviewers or maintainers to validate the changes.  
> Include commands, scripts, or datasets if relevant.  
> Full validation results should be referenced in the associated issue, not pasted here.

- Ran WaveDiff training and metrics pipeline tasks sequentially on simulated dataset in short-run mode and observed pipeline executed to completion without error
- Ran WaveDiff metrics pipeline on previously trained model in long run mode and observed pipeline executed to completion without error and the results are consistent with previous validation runs. Small precision errors observed but I am running at CC-IN2P3, with newer version of TF, Adam optimizer, possibly different random seed.


## Scope

> Indicate the type of PR:

- [ ] Feature  
- [X] Bug fix  
- [ ] Hotfix  
- [ ] Documentation / process change  
- [ ] Internal / refactor  
- [ ] Release

> Optionally, note if this PR is part of a larger milestone or set of related PRs.


## Changelog

> Did this PR introduce user-visible changes?  
> If yes, a **Scriv changelog fragment** must be added and committed.

- [ ] Changelog fragment added (if applicable)
No, I will update the changelog for the release branch.

## Reviewer Checklist

> Reviewers should confirm the following before approving and merging:

- [x] The PR targets the correct base branch (`develop`, or `main` for release PRs)
- [x] The PR is assigned to the developer
- [x] Appropriate labels are applied
- [x] The PR is included in relevant projects and/or milestones
- [x] Description clearly explains what has changed
- [x] Issue references included, if applicable
- [x] Code and documentation adhere to current standards (`ruff`)
- [x] Documentation updates included, if relevant
- [x] CI tests are passing
- [x] All reviewer comments have been addressed


## Next Steps / Notes (if applicable)

> Any follow-up actions, known issues, or reminders for maintainers.

