### PR TITLE
220 bug inference arbitrary fov positions

### DIFF
--- a/changelog.d/20260603_132526_jennifer.pollack_220_bug_inference_arbitrary_fov_positions.md
+++ b/changelog.d/20260603_132526_jennifer.pollack_220_bug_inference_arbitrary_fov_positions.md
@@ -1,0 +1,35 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking changes
+
+- A bullet item for the Breaking changes category.
+
+-->
+<!--
+### New features
+
+- A bullet item for the New features category.
+
+-->
+### Bug fixes
+
+- Fixed inference error for random FOV positions due to inference data positions not being passed to physical layer PSF model
+
+<!--
+### Performance improvements
+
+- A bullet item for the Performance improvements category.
+
+-->
+<!--
+### Internal changes
+
+- A bullet item for the Internal changes category.
+
+-->

--- a/src/wf_psf/inference/psf_inference.py
+++ b/src/wf_psf/inference/psf_inference.py
@@ -379,17 +379,18 @@ class PSFInference:
             # Use the factory — it will normalize, convert dicts/dataclasses, and produce LoadedDataset
             adapter = DataAdapterFactory.build(dataset)
 
-            # Convert to TensorFlow according to dataset schema mode
-            if adapter.representation_state == RepresentationState.NUMPY:
-                adapter.convert_to_tensorflow(
-                    self.simPSF,
-                    self.n_bins_lambda,
-                    mode=self.config_handler.schema_mode,
-                )
-
             self._inference_data_adapter = adapter
 
         return self._inference_data_adapter
+
+    def _convert_inference_data_to_tensorflow(self):
+        # Convert to TensorFlow according to dataset schema mode
+        if self._inference_data_adapter.representation_state == RepresentationState.NUMPY:
+            self._inference_data_adapter.convert_to_tensorflow(
+                self.simPSF,
+                self.n_bins_lambda,
+                mode=self.config_handler.schema_mode,
+            )
 
     @property
     def trained_psf_model(self):
@@ -469,7 +470,7 @@ class PSFInference:
         # Load the trained PSF model
         return load_trained_psf_model(
             self.training_config,
-            self.model_data_adapter.complete_data,
+            self.inference_data_adapter.complete_data,
             weights_path_pattern,
         )
 
@@ -543,15 +544,18 @@ class PSFInference:
         # Prepare the configuration for inference
         self.prepare_configs()
 
-        # Get positions and SEDs
-        positions = self.inference_data_adapter.complete_data["positions"]
-        sed_data = self.inference_data_adapter.complete_data["seds"]
-
         self.engine = PSFInferenceEngine(
             trained_model=self.trained_psf_model,
             batch_size=self.batch_size,
             output_dim=self.output_dim,
         )
+
+        # Convert inference data to tensorflow type
+        self._convert_inference_data_to_tensorflow()
+
+        # Get positions and SEDs
+        positions = self.inference_data_adapter.complete_data["positions"]
+        sed_data = self.inference_data_adapter.complete_data["seds"]
 
         return self.engine.compute_psfs(positions, sed_data)
 

--- a/src/wf_psf/tests/test_inference/psf_inference_test.py
+++ b/src/wf_psf/tests/test_inference/psf_inference_test.py
@@ -574,6 +574,6 @@ def test_engine_clear_cache(psf_test_setup):
     inference.engine.clear_cache()
 
     # Check that the internal cache is None
-    assert (
-        inference.engine._inferred_psfs is None
-    ), "PSF cache should be cleared to None"
+    assert inference.engine._inferred_psfs is None, (
+        "PSF cache should be cleared to None"
+    )

--- a/src/wf_psf/tests/test_inference/psf_inference_test.py
+++ b/src/wf_psf/tests/test_inference/psf_inference_test.py
@@ -67,7 +67,13 @@ def mock_inference_config():
                 trained_model_config_path="config/training_config.yaml",
                 data_config_path=None,
             ),
-            model_params=RecursiveNamespace(n_bins_lambda=8, output_Q=1, output_dim=64, correct_centroids=False, add_ccd_misalignments=True),
+            model_params=RecursiveNamespace(
+                n_bins_lambda=8,
+                output_Q=1,
+                output_dim=64,
+                correct_centroids=False,
+                add_ccd_misalignments=True,
+            ),
         )
     )
     return inference_config
@@ -318,7 +324,7 @@ def test_batch_size_positive():
     inference = PSFInference("dummy_path.yaml")
     inference._config_handler = MagicMock()
     inference._config_handler.inference_config = SimpleNamespace(
-            batch_size=4, model_params=SimpleNamespace(output_dim=32)
+        batch_size=4, model_params=SimpleNamespace(output_dim=32)
     )
     assert inference.batch_size == 4
 
@@ -347,11 +353,6 @@ def test_data_adapter_property_adapter_build(
 
     assert adapter == mock_data_adapter
     mock_build.assert_called_once()
-    mock_data_adapter.convert_to_tensorflow.assert_called_once_with(
-        inference.simPSF,
-        inference.n_bins_lambda,
-        mode=inference.config_handler.schema_mode,
-    )
 
 
 @patch("wf_psf.inference.psf_inference.DataAdapterFactory.build")
@@ -391,7 +392,7 @@ def test_load_inference_model(
     mock_adapter = MagicMock()
     mock_adapter.complete_data = {"positions": np.zeros((2, 2))}
 
-    psf_inf = PSFInference("dummy_path.yaml")
+    psf_inf = PSFInference("dummy_path.yaml", x_field=2, y_field=2)
 
     mock_config_handler = MagicMock(spec=InferenceConfigHandler)
     mock_config_handler.trained_model_path = "mock/path/to/model"
@@ -445,6 +446,11 @@ def test_run_inference(
     assert psfs.shape == expected_psfs.shape
     mock_prepare_configs.assert_called_once()
     mock_compute_psfs.assert_called_once_with(mock_positions, mock_seds)
+    mock_data_adapter.convert_to_tensorflow.assert_called_once_with(
+        inference.simPSF,
+        inference.n_bins_lambda,
+        mode=inference.config_handler.schema_mode,
+    )
 
 
 @patch("wf_psf.inference.psf_inference.psf_models.simPSF")
@@ -568,6 +574,6 @@ def test_engine_clear_cache(psf_test_setup):
     inference.engine.clear_cache()
 
     # Check that the internal cache is None
-    assert inference.engine._inferred_psfs is None, (
-        "PSF cache should be cleared to None"
-    )
+    assert (
+        inference.engine._inferred_psfs is None
+    ), "PSF cache should be cleared to None"


### PR DESCRIPTION
## Summary

Inference doesn't work for random positions in FOV limits described in #220.

Closes #220 


## What’s changed

- Updates to `psf_inference.py` and `psf_inference_test.py`
- Replace `model_data_adapter.complete_data` with `inference_data_adapter.complete_data` in the `data` arg to `load_trained_psf_model` function
- Add helper `_convert_inference_data_to_tensorflow`
- Change orchestration of data adaptation by doing the conversion after the trained psf model has been loaded 

## How to test / verify

> Outline steps for reviewers or maintainers to validate the changes.  
> Include commands, scripts, or datasets if relevant.  
> Full validation results should be referenced in the associated issue, not pasted here.

- Run pytest
- Performed validation exercises results see issue #220 comment  repeatability exercise for EVALUATION data schema pass


## Scope

> Indicate the type of PR:

- [ ] Feature  
- [X] Bug fix  
- [ ] Hotfix  
- [ ] Documentation / process change  
- [ ] Internal / refactor  
- [ ] Release

> Optionally, note if this PR is part of a larger milestone or set of related PRs.


## Changelog

> Did this PR introduce user-visible changes?  
> If yes, a **Scriv changelog fragment** must be added and committed.

- [X] Changelog fragment added (if applicable)


## Reviewer Checklist

> Reviewers should confirm the following before approving and merging:

- [x] The PR targets the correct base branch (`develop`, or `main` for release PRs)
- [x] The PR is assigned to the developer
- [x] Appropriate labels are applied
- [x] The PR is included in relevant projects and/or milestones
- [x] Description clearly explains what has changed
- [x] Issue references included, if applicable
- [x] Code and documentation adhere to current standards (`ruff`)
- [x] Documentation updates included, if relevant
- [x] CI tests are passing
- [x] All reviewer comments have been addressed


## Next Steps / Notes (if applicable)

> Any follow-up actions, known issues, or reminders for maintainers.

