### PR TITLE
231 architecture introduce generic registry utility

### DIFF
--- a/src/wf_psf/tests/test_utils/registry_test.py
+++ b/src/wf_psf/tests/test_utils/registry_test.py
@@ -12,7 +12,6 @@ from wf_psf.utils.registry import Registry
 
 
 def test_register_and_get():
-
     registry = Registry[str, int]()
 
     registry.register("one", 1)
@@ -21,7 +20,6 @@ def test_register_and_get():
 
 
 def test_register_duplicate_key_raises():
-
     registry = Registry[str, int]()
 
     registry.register("one", 1)
@@ -34,7 +32,6 @@ def test_register_duplicate_key_raises():
 
 
 def test_get_unknown_key_raises():
-
     registry = Registry[str, int]()
 
     with pytest.raises(
@@ -45,7 +42,6 @@ def test_get_unknown_key_raises():
 
 
 def test_unregister():
-
     registry = Registry[str, int]()
 
     registry.register("one", 1)
@@ -56,7 +52,6 @@ def test_unregister():
 
 
 def test_unregister_unknown_key_raises():
-
     registry = Registry[str, int]()
 
     with pytest.raises(
@@ -67,7 +62,6 @@ def test_unregister_unknown_key_raises():
 
 
 def test_contains():
-
     registry = Registry[str, int]()
 
     registry.register("one", 1)
@@ -77,7 +71,6 @@ def test_contains():
 
 
 def test_keys():
-
     registry = Registry[str, int]()
 
     registry.register("one", 1)
@@ -87,7 +80,6 @@ def test_keys():
 
 
 def test_values():
-
     registry = Registry[str, int]()
 
     registry.register("one", 1)
@@ -97,7 +89,6 @@ def test_values():
 
 
 def test_items():
-
     registry = Registry[str, int]()
 
     registry.register("one", 1)
@@ -110,7 +101,6 @@ def test_items():
 
 
 def test_iteration():
-
     registry = Registry[str, int]()
 
     registry.register("one", 1)
@@ -123,7 +113,6 @@ def test_iteration():
 
 
 def test_get_falsey_value():
-
     registry = Registry[str, int]()
 
     registry.register("zero", 0)
@@ -132,7 +121,6 @@ def test_get_falsey_value():
 
 
 def test_get_false_boolean():
-
     registry = Registry[str, bool]()
 
     registry.register("flag", False)

--- a/src/wf_psf/tests/test_utils/registry_test.py
+++ b/src/wf_psf/tests/test_utils/registry_test.py
@@ -1,0 +1,140 @@
+"""UNIT TESTS FOR PACKAGE MODULE: Generic Registry Utility.
+
+This module contains unit tests for the generic Registry class.
+
+:Author:
+    Jennifer Pollack <jennifer.pollack@cea.fr>
+"""
+
+import pytest
+
+from wf_psf.utils.registry import Registry
+
+
+def test_register_and_get():
+
+    registry = Registry[str, int]()
+
+    registry.register("one", 1)
+
+    assert registry.get("one") == 1
+
+
+def test_register_duplicate_key_raises():
+
+    registry = Registry[str, int]()
+
+    registry.register("one", 1)
+
+    with pytest.raises(
+        ValueError,
+        match="Key 'one' is already registered.",
+    ):
+        registry.register("one", 2)
+
+
+def test_get_unknown_key_raises():
+
+    registry = Registry[str, int]()
+
+    with pytest.raises(
+        KeyError,
+        match="Key 'missing' not found in registry.",
+    ):
+        registry.get("missing")
+
+
+def test_unregister():
+
+    registry = Registry[str, int]()
+
+    registry.register("one", 1)
+
+    registry.unregister("one")
+
+    assert "one" not in registry
+
+
+def test_unregister_unknown_key_raises():
+
+    registry = Registry[str, int]()
+
+    with pytest.raises(
+        KeyError,
+        match="Key 'missing' not found in registry.",
+    ):
+        registry.unregister("missing")
+
+
+def test_contains():
+
+    registry = Registry[str, int]()
+
+    registry.register("one", 1)
+
+    assert "one" in registry
+    assert "two" not in registry
+
+
+def test_keys():
+
+    registry = Registry[str, int]()
+
+    registry.register("one", 1)
+    registry.register("two", 2)
+
+    assert set(registry.keys()) == {"one", "two"}
+
+
+def test_values():
+
+    registry = Registry[str, int]()
+
+    registry.register("one", 1)
+    registry.register("two", 2)
+
+    assert set(registry.values()) == {1, 2}
+
+
+def test_items():
+
+    registry = Registry[str, int]()
+
+    registry.register("one", 1)
+    registry.register("two", 2)
+
+    assert set(registry.items()) == {
+        ("one", 1),
+        ("two", 2),
+    }
+
+
+def test_iteration():
+
+    registry = Registry[str, int]()
+
+    registry.register("one", 1)
+    registry.register("two", 2)
+
+    assert set(registry) == {
+        ("one", 1),
+        ("two", 2),
+    }
+
+
+def test_get_falsey_value():
+
+    registry = Registry[str, int]()
+
+    registry.register("zero", 0)
+
+    assert registry.get("zero") == 0
+
+
+def test_get_false_boolean():
+
+    registry = Registry[str, bool]()
+
+    registry.register("flag", False)
+
+    assert registry.get("flag") is False

--- a/src/wf_psf/utils/registry.py
+++ b/src/wf_psf/utils/registry.py
@@ -68,6 +68,7 @@ class Registry(Generic[K, V]):
         ------
         KeyError
             If the key is not present in the registry.
+
         """
         try:
             return self._store[key]
@@ -86,6 +87,7 @@ class Registry(Generic[K, V]):
         ------
         KeyError
           If key is not present in registry.
+
         """
         if key not in self._store:
             raise KeyError(f"Key '{key}' not found in registry.")

--- a/src/wf_psf/utils/registry.py
+++ b/src/wf_psf/utils/registry.py
@@ -1,0 +1,123 @@
+"""Generic registry utility.
+
+Provides a reusable implementation of the Registry pattern for
+registering and retrieving objects by a unique key.
+
+The generic registry serves as a foundation for building
+domain-specific registries throughout WaveDiff (e.g. quality metrics,
+rejection policies, etc.), while keeping registration and lookup behaviour
+consistent across the codebase.
+
+:Authors: Jennifer Pollack <jennifer.pollack@cea.fr>
+
+"""
+
+from typing import Generic, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class Registry(Generic[K, V]):
+    """Generic registry implementation.
+
+    Stores objects under unique keys and provides registration,
+    lookup, and iteration operations.
+
+    The registry is intended to be specialised by domain-specific
+    registries rather than used directly by application code.
+    """
+
+    def __init__(self):
+        """Initialize the registry with an empty internal store."""
+        self._store: dict[K, V] = {}
+
+    def register(self, key: K, value: V) -> None:
+        """Register a value under a unique key.
+
+        Parameters
+        ----------
+        key : Key
+            Unique identifier used to register the value.
+        value : Value
+            Object to register.
+
+        Raises
+        ------
+        ValueError
+            If the key is already registered.
+        """
+        if key in self._store:
+            raise ValueError(f"Key '{key}' is already registered.")
+        self._store[key] = value
+
+    def get(self, key: K) -> V:
+        """Retrieve the value registered under a given key.
+
+        Parameters
+        ----------
+        key : Key
+            Unique identifier for the registered object.
+
+        Returns
+        -------
+        V
+            Registered object.
+
+        Raises
+        ------
+        KeyError
+            If the key is not present in the registry.
+        """
+        try:
+            return self._store[key]
+        except KeyError:
+            raise KeyError(f"Key '{key}' not found in registry.") from None
+
+    def unregister(self, key: K) -> None:
+        """Remove a key:value pair from the registry.
+
+        Parameters
+        ----------
+        key : K
+            Unique identifier of the item to remove.
+
+        Raises
+        ------
+        KeyError
+          If key is not present in registry.
+        """
+        if key not in self._store:
+            raise KeyError(f"Key '{key}' not found in registry.")
+        del self._store[key]
+
+    def __contains__(self, key: K) -> bool:
+        """Return whether a key is registered.
+
+        Parameter
+        ---------
+        key : K
+            Key to test.
+
+        Returns
+        -------
+        bool
+            True if the key is present in the registry, otherwise False.
+        """
+        return key in self._store
+
+    def __iter__(self):
+        """Iterate over registered (key, value) pairs."""
+        return iter(self._store.items())
+
+    def keys(self):
+        """Return a view of the registered keys."""
+        return self._store.keys()
+
+    def values(self):
+        """Return a view of the registered values."""
+        return self._store.values()
+
+    def items(self):
+        """Return a view of the registered (key, value) pairs."""
+        return self._store.items()


### PR DESCRIPTION
## Summary

Introduces a generic `Registry` utility for registering and retrieving objects by a unique key. The registry provides a reusable foundation for building domain-specific registries throughout WaveDiff (e.g. quality metrics, rejection policies, etc.), while keeping registration and lookup behaviour consistent across the codebase.

Closes #231.

---

## What’s changed

* Added a reusable generic `Registry[K, V]` implementation under `wf_psf.utils.registry`.
* Implemented registration, lookup, removal, iteration, and membership operations.
* Added validation to prevent duplicate registrations and provide informative errors for unknown keys.
* Added comprehensive unit tests covering registration, lookup, duplicate registration, removal, iteration, membership, and error handling.

---

## How to test / verify

* Run the registry unit tests:

  ```bash
  pytest src/wf_psf/tests/test_utils/registry_test.py
  ```
* Optionally run the full test suite:

  ```bash
  pytest
  ```

---

## Scope

* [ ] Feature
* [ ] Bug fix
* [ ] Hotfix
* [ ] Documentation / process change
* [x] Internal / refactor
* [ ] Release

This PR introduces a reusable architectural utility that will be used by future domain-specific registries, including the forthcoming Quality Control framework.

---

## Changelog

This PR introduces an internal utility only and does not change user-facing functionality.

* [ ] Changelog fragment added (not applicable)

---

## Reviewer Checklist

* [x] The PR targets the correct base branch (`develop`, or `main` for release PRs)
* [x] The PR is assigned to the developer
* [x] Appropriate labels are applied
* [x] The PR is included in relevant projects and/or milestones
* [x] Description clearly explains what has changed
* [x] Issue references included, if applicable
* [x] Code and documentation adhere to current standards (`ruff`)
* [x] Documentation updates included, if relevant
* [x] CI tests are passing
* [x] All reviewer comments have been addressed

---

## Next Steps / Notes (if applicable)

This registry provides the foundation for future architecture work. Follow-up PRs will introduce domain-specific registries (e.g. `MetricsRegistry` and `RejectionPolicyRegistry`) that build upon this generic implementation.
