### PR TITLE
235 architecture introduce quality control rejection policy registry

### DIFF
--- a/changelog.d/20260803_170949_jennifer.pollack_235_architecture_introduce_quality_control_rejection_policy_registry.md
+++ b/changelog.d/20260803_170949_jennifer.pollack_235_architecture_introduce_quality_control_rejection_policy_registry.md
@@ -1,0 +1,37 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking changes
+
+- A bullet item for the Breaking changes category.
+
+-->
+### New features
+
+- Added the rejection policy registry framework, introducing a reusable
+  `RejectionPolicyRegistry` and `RejectionPolicy` interface to support
+  extensible sample rejection strategies within the quality control pipeline.
+
+<!--
+### Bug fixes
+
+- A bullet item for the Bug fixes category.
+
+-->
+<!--
+### Performance improvements
+
+- A bullet item for the Performance improvements category.
+
+-->
+<!--
+### Internal changes
+
+- A bullet item for the Internal changes category.
+
+-->

--- a/src/wf_psf/quality_control/metrics/base.py
+++ b/src/wf_psf/quality_control/metrics/base.py
@@ -12,6 +12,7 @@ training, evaluation, or inference.
 """
 
 from abc import ABC, abstractmethod
+import numpy as np
 
 
 class QualityMetric(ABC):
@@ -34,5 +35,5 @@ class QualityMetric(ABC):
     name: str
 
     @abstractmethod
-    def compute(self, dataset):
+    def compute(self, dataset) -> np.ndarray:
         """Compute the quality metric for the supplied dataset."""

--- a/src/wf_psf/quality_control/metrics/base.py
+++ b/src/wf_psf/quality_control/metrics/base.py
@@ -36,4 +36,18 @@ class QualityMetric(ABC):
 
     @abstractmethod
     def compute(self, dataset) -> np.ndarray:
-        """Compute the quality metric for the supplied dataset."""
+        """Compute the quality metric for the supplied dataset.
+
+        Parameters
+        ----------
+        dataset
+            Dataset containing the samples to be evaluated. A dataset may
+            contain multiple postage stamps/images and their associated
+            metadata or auxiliary data, depending on the requirements of
+            the metric.
+
+        Returns
+        -------
+        np.ndarray
+            One metric value per dataset sample.
+        """

--- a/src/wf_psf/quality_control/rejection/base.py
+++ b/src/wf_psf/quality_control/rejection/base.py
@@ -28,7 +28,8 @@ class RejectionPolicy(ABC):
     Methods
     -------
     apply(metric)
-        Apply the rejection policy to the supplied quality metric and return a boolean validity mask.
+        Apply the rejection policy to the supplied quality metric and
+        return a boolean validity mask.
 
     """
 
@@ -36,4 +37,7 @@ class RejectionPolicy(ABC):
 
     @abstractmethod
     def apply(self, metric: np.ndarray) -> np.ndarray:
-        """Return a boolean validity mask identifying valid dataset samples."""
+        """Return a boolean mask identifying valid dataset samples.
+
+        The returned mask has one entry per dataset sample.
+        """

--- a/src/wf_psf/quality_control/rejection/base.py
+++ b/src/wf_psf/quality_control/rejection/base.py
@@ -3,18 +3,37 @@
 Defines the abstract interface implemented by rejection policies.
 
 Rejection policies convert quality metrics into boolean validity masks.
-This separation allows metric computation and rejection decisions to
-evolve independently.
+These masks are used by the quality control pipeline to identify valid
+dataset samples for downstream processing, such as model training,
+evaluation, or inference.
 
 :Authors: Jennifer Pollack <jennifer.pollack@cea.fr>
 
 """
 
 from abc import ABC, abstractmethod
+import numpy as np
+
 
 class RejectionPolicy(ABC):
-    """Abstract interface for quality-based sample rejection."""
+    """Abstract interface for sample rejection policy implementations.
+
+    Attributes
+    ----------
+    name : str
+        Unique identifier for the rejection policy implementation. Used by
+        the RejectionPolicyRegistry to register and retrieve rejection
+        policy classes.
+
+    Methods
+    -------
+    apply(metric)
+        Apply the rejection policy to the supplied quality metric and return a boolean validity mask.
+
+    """
+
+    name: str
 
     @abstractmethod
-    def apply(self, metric):
-        """Return a boolean validity mask from a quality metric."""
+    def apply(self, metric: np.ndarray) -> np.ndarray:
+        """Return a boolean validity mask identifying valid dataset samples."""

--- a/src/wf_psf/quality_control/rejection/registry.py
+++ b/src/wf_psf/quality_control/rejection/registry.py
@@ -9,3 +9,34 @@ modifying the quality control pipeline.
 :Authors:
     Jennifer Pollack <jennifer.pollack@cea.fr>
 """
+
+from wf_psf.quality_control.rejection.base import RejectionPolicy
+from wf_psf.quality_control.rejection.threshold import ThresholdRejectionPolicy
+from wf_psf.utils.registry import Registry
+
+
+class RejectionPolicyRegistry(Registry[str, type[RejectionPolicy]]):
+    """Rejection policy registry class."""
+
+    def register_rejection_policy(self, rejection_cls: type[RejectionPolicy]) -> None:
+        """Register a rejection policy implementation.
+
+        Registers a class of type[RejectionPolicy] using the attribute
+        `name` as a key, and the class as a value.
+
+        Parameters
+        ----------
+        rejection_cls : type[RejectionPolicy]
+            Rejection policy class to register
+
+        """
+        self.register(rejection_cls.name, rejection_cls)
+
+
+def build_rejection_policy_registry() -> RejectionPolicyRegistry:
+    """Build rejection policy registry."""
+    registry = RejectionPolicyRegistry()
+
+    registry.register_rejection_policy(ThresholdRejectionPolicy)
+
+    return registry

--- a/src/wf_psf/quality_control/rejection/registry.py
+++ b/src/wf_psf/quality_control/rejection/registry.py
@@ -1,10 +1,11 @@
 """Quality control rejection policy registry.
 
-Provides the registry responsible for constructing rejection policies from configuration.
+Provides the registry responsible for storing and retrieving rejection
+policy implementations.
 
-The registry decouples configuration parsing from rejection policy
-instantiation, allowing new rejection policies to be registered without
-modifying the quality control pipeline.
+The registry decouples rejection policy lookup from pipeline logic,
+allowing new rejection policies to be registered without modifying the
+quality control pipeline.
 
 :Authors:
     Jennifer Pollack <jennifer.pollack@cea.fr>
@@ -16,7 +17,7 @@ from wf_psf.utils.registry import Registry
 
 
 class RejectionPolicyRegistry(Registry[str, type[RejectionPolicy]]):
-    """Rejection policy registry class."""
+    """Registry storing available sample rejection policies."""
 
     def register_rejection_policy(self, rejection_cls: type[RejectionPolicy]) -> None:
         """Register a rejection policy implementation.

--- a/src/wf_psf/quality_control/rejection/threshold.py
+++ b/src/wf_psf/quality_control/rejection/threshold.py
@@ -12,13 +12,14 @@ modifying the quality control pipeline.
 """
 
 from .base import RejectionPolicy
+import numpy as np
 
 
 class ThresholdRejectionPolicy(RejectionPolicy):
-    """Reject dataset samples according to configurable metric thresholds."""
+    """Reject dataset samples based on configurable metric thresholds."""
 
     name = "threshold"
 
-    def apply(self, metric):
-        """Apply threshold policy."""
+    def apply(self, metric: np.ndarray) -> np.ndarray:
+        """Apply threshold-based rejection to metric values."""
         raise NotImplementedError

--- a/src/wf_psf/quality_control/rejection/threshold.py
+++ b/src/wf_psf/quality_control/rejection/threshold.py
@@ -10,3 +10,15 @@ modifying the quality control pipeline.
 :Authors:
     Jennifer Pollack <jennifer.pollack@cea.fr>
 """
+
+from .base import RejectionPolicy
+
+
+class ThresholdRejectionPolicy(RejectionPolicy):
+    """Reject dataset samples according to configurable metric thresholds."""
+
+    name = "threshold"
+
+    def apply(self, metric):
+        """Apply threshold policy."""
+        raise NotImplementedError

--- a/src/wf_psf/tests/test_quality_control/test_qc_rejection_policy/qc_rejection_registry_test.py
+++ b/src/wf_psf/tests/test_quality_control/test_qc_rejection_policy/qc_rejection_registry_test.py
@@ -6,6 +6,7 @@ This module contains unit tests for the RejectionPolicyRegistry class.
     Jennifer Pollack <jennifer.pollack@cea.fr>
 """
 
+import numpy as np
 import pytest
 from wf_psf.quality_control.rejection.base import RejectionPolicy
 from wf_psf.quality_control.rejection.registry import (
@@ -21,8 +22,8 @@ class CustomRejectionPolicy(RejectionPolicy):
     name = "custom_policy"
 
     def apply(self, metric) -> None:
-        """Dummy implementation for testing."""
-        return None
+        """Return a dummy validity mask for testing."""
+        return np.ones(metric.shape, dtype=bool)
 
 
 def test_build_rejection_registry():
@@ -52,4 +53,12 @@ def test_custom_policy_registration():
 
     registry.register_rejection_policy(CustomRejectionPolicy)
 
-    assert registry.get("custom_policy") is CustomRejectionPolicy
+    policy_cls = registry.get("custom_policy")
+    policy = policy_cls()
+
+    metric = np.array([0.1, 0.5, 0.9])
+    result = policy.apply(metric)
+
+    assert isinstance(result, np.ndarray)
+    assert result.shape == metric.shape
+    assert result.dtype == bool

--- a/src/wf_psf/tests/test_quality_control/test_qc_rejection_policy/qc_rejection_registry_test.py
+++ b/src/wf_psf/tests/test_quality_control/test_qc_rejection_policy/qc_rejection_registry_test.py
@@ -1,0 +1,55 @@
+"""UNIT TESTS FOR PACKAGE MODULE: Quality Control Rejection Policy Registry.
+
+This module contains unit tests for the RejectionPolicyRegistry class.
+
+:Author:
+    Jennifer Pollack <jennifer.pollack@cea.fr>
+"""
+
+import pytest
+from wf_psf.quality_control.rejection.base import RejectionPolicy
+from wf_psf.quality_control.rejection.registry import (
+    RejectionPolicyRegistry,
+    build_rejection_policy_registry,
+)
+from wf_psf.quality_control.rejection.threshold import ThresholdRejectionPolicy
+
+
+class CustomRejectionPolicy(RejectionPolicy):
+    """Test rejection policy used to verify registry extensibility."""
+
+    name = "custom_policy"
+
+    def apply(self, metric) -> None:
+        """Dummy implementation for testing."""
+        return None
+
+
+def test_build_rejection_registry():
+    registry = build_rejection_policy_registry()
+
+    assert registry.get("threshold") is ThresholdRejectionPolicy
+
+
+def test_duplicate_rejection_policy_registration_raises():
+    registry = RejectionPolicyRegistry()
+
+    registry.register_rejection_policy(ThresholdRejectionPolicy)
+
+    with pytest.raises(ValueError):
+        registry.register_rejection_policy(ThresholdRejectionPolicy)
+
+
+def test_unknown_policy_raises():
+    registry = build_rejection_policy_registry()
+
+    with pytest.raises(KeyError):
+        registry.get("unknown_policy")
+
+
+def test_custom_policy_registration():
+    registry = build_rejection_policy_registry()
+
+    registry.register_rejection_policy(CustomRejectionPolicy)
+
+    assert registry.get("custom_policy") is CustomRejectionPolicy

--- a/src/wf_psf/tests/test_quality_control/test_qc_rejection_policy/qc_rejection_registry_test.py
+++ b/src/wf_psf/tests/test_quality_control/test_qc_rejection_policy/qc_rejection_registry_test.py
@@ -21,7 +21,7 @@ class CustomRejectionPolicy(RejectionPolicy):
 
     name = "custom_policy"
 
-    def apply(self, metric) -> None:
+    def apply(self, metric) -> np.ndarray:
         """Return a dummy validity mask for testing."""
         return np.ones(metric.shape, dtype=bool)
 


### PR DESCRIPTION
## Summary

Introduces the rejection policy registry framework for the Quality Control
pipeline.

This PR refines the `RejectionPolicy` interface documentation and adds
`RejectionPolicyRegistry` to provide an extensible mechanism for registering
and retrieving sample rejection policies.

closes #235


## What’s changed

- Refined the `RejectionPolicy` abstract interface documentation to clarify
  the contract for converting quality metric values into boolean sample
  validity masks.

- Added `RejectionPolicyRegistry` based on the generic registry framework
  to support extensible registration and retrieval of rejection policy
  implementations.

- Added the initial `ThresholdRejectionPolicy` implementation as a concrete
  rejection policy example.

- Added registry unit tests covering:
  - built-in rejection policy registration
  - duplicate registration handling
  - unknown policy lookup failures
  - custom rejection policy registration

- Updated rejection policy documentation to clarify the relationship
  between quality metrics and sample filtering.

## How to test / verify

- Run the Quality Control rejection policy unit tests:

```

pytest src/wf_psf/tests/test_quality_control/test_qc_rejection_policy/

```

- Verify that:
  - the default rejection policy registry is correctly populated;
  - registered policies can be retrieved by name;
  - duplicate and unknown registrations raise the expected errors;
  - custom rejection policies following the `RejectionPolicy` interface can
    be registered.


## Scope

- [X] Feature  
- [ ] Bug fix  
- [ ] Hotfix  
- [ ] Documentation / process change  
- [ ] Internal / refactor  
- [ ] Release  

Part of the Quality Control framework architecture work.


## Changelog

Did this PR introduce user-visible changes?

- [X] Changelog fragment added (if applicable)


## Reviewer Checklist

> Reviewers should confirm the following before approving and merging:

- [x] The PR targets the correct base branch (`develop`, or `main` for release PRs)
- [x] The PR is assigned to the developer
- [x] Appropriate labels are applied
- [x] The PR is included in relevant projects and/or milestones
- [x] Description clearly explains what has changed
- [x] Issue references included, if applicable
- [x] Code and documentation adhere to current standards (`ruff`)
- [x] Documentation updates included, if relevant
- [x] CI tests are passing
- [ ] All reviewer comments have been addressed


## Next Steps / Notes (if applicable)

- Future work will integrate rejection policy construction from quality
control configuration settings.

- Additional rejection policy implementations can be added following the
`RejectionPolicy` interface without modifying the quality control pipeline.
