### PR TITLE
Generalise rejection policy configuration

### DIFF
--- a/config/quality_control.yaml
+++ b/config/quality_control.yaml
@@ -32,7 +32,9 @@ rejection:
 
   goodness_of_fit:
     enabled: false
-    threshold: 3.0
+    policy:
+      threshold:
+        value: 3.0
 
 reporting:
 

--- a/src/wf_psf/quality_control/config.py
+++ b/src/wf_psf/quality_control/config.py
@@ -47,12 +47,12 @@ class RejectionPolicyConfig:
     enabled : bool
         Whether rejection policy is enabled.
 
-    threshold : float | None
-        Numeric threshold used by the rejection policy, or None if not applicable.
+    policy : dict[str, Any]
+        Rejection policy configuration keyed by policy type.
     """
 
     enabled: bool = False
-    threshold: float | None = None
+    policy: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -153,7 +153,7 @@ def parse_metrics_config(
         enabled = cfg.get("enabled", True)
 
         if not isinstance(enabled, bool):
-            raise TypeError(f"Metric enabled flag for '{name}' must be boolean.")
+            raise TypeError(f"Metric `enabled` flag for '{name}' must be boolean.")
 
         params = cfg.get("params", {})
 
@@ -198,6 +198,9 @@ def parse_rejection_policy_config(
     TypeError
         If the configuration section or a policy configuration is not a
         mapping.
+
+    ValueError
+        If the policy configuration for a metric does not specify exactly one policy.
     """
     if section is None:
         return {}
@@ -207,13 +210,51 @@ def parse_rejection_policy_config(
 
     policies = {}
 
-    for name, cfg in section.items():
+    for metric_name, cfg in section.items():
         if not isinstance(cfg, Mapping):
             raise TypeError(
-                f"Rejection policy configuration '{name}' must be a mapping."
+                f"Rejection policy configuration '{metric_name}' must be a mapping."
             )
 
-        policies[name] = RejectionPolicyConfig(**cfg)
+        enabled = cfg.get("enabled", True)
+
+        if not isinstance(enabled, bool):
+            raise TypeError(
+                f"Rejection policy `enabled` flag for '{metric_name}' must be boolean."
+            )
+
+        if not enabled:
+            policies[metric_name] = RejectionPolicyConfig(enabled=False)
+            continue
+
+        policy = cfg.get("policy", {})
+
+        if not isinstance(policy, Mapping):
+            raise TypeError(
+                f"Rejection policy `policy` field for '{metric_name}' must be a mapping."
+            )
+
+        if len(policy) != 1:
+            raise ValueError(
+                f"Rejection policy configuration for '{metric_name}' "
+                "must specify exactly one policy type."
+            )
+
+        policy_name, policy_params = next(iter(policy.items()))
+
+        if not isinstance(policy_name, str):
+            raise TypeError(
+                f"Rejection policy identifier '{policy_name}' for '{metric_name}' must be a string."
+            )
+
+        if not isinstance(policy_params, Mapping):
+            raise TypeError(
+                f"Rejection policy parameters for '{metric_name}' must be a mapping."
+            )
+
+        policies[metric_name] = RejectionPolicyConfig(
+            enabled=enabled, policy=dict(policy)
+        )
 
     return policies
 

--- a/src/wf_psf/quality_control/config.py
+++ b/src/wf_psf/quality_control/config.py
@@ -146,31 +146,35 @@ def parse_metrics_config(
 
     metrics = {}
 
-    for name, cfg in section.items():
+    for metric_name, cfg in section.items():
         if not isinstance(cfg, Mapping):
-            raise TypeError(f"Metric configuration '{name}' must be a mapping.")
+            raise TypeError(f"Metric configuration '{metric_name}' must be a mapping.")
 
         enabled = cfg.get("enabled", False)
 
         if not isinstance(enabled, bool):
-            raise TypeError(f"Metric `enabled` flag for '{name}' must be boolean.")
+            raise TypeError(
+                f"Metric `enabled` flag for '{metric_name}' must be boolean."
+            )
 
         params = cfg.get("params", {})
 
         if not isinstance(params, Mapping):
-            raise TypeError(f"Metric parameters for '{name}' must be a mapping.")
+            raise TypeError(f"Metric parameters for '{metric_name}' must be a mapping.")
 
         required_resources = cfg.get("required_resources", [])
 
         if not isinstance(required_resources, list):
-            raise TypeError(f"Required resources for metric '{name}' must be a list.")
+            raise TypeError(
+                f"Required resources for metric '{metric_name}' must be a list."
+            )
 
         if not all(isinstance(resource, str) for resource in required_resources):
             raise TypeError(
-                f"Required resources for metric '{name}' must contain only strings."
+                f"Required resources for metric '{metric_name}' must contain only strings."
             )
 
-        metrics[name] = QualityMetricConfig(
+        metrics[metric_name] = QualityMetricConfig(
             enabled=enabled, params=dict(params), required_resources=required_resources
         )
 

--- a/src/wf_psf/quality_control/config.py
+++ b/src/wf_psf/quality_control/config.py
@@ -33,7 +33,7 @@ class QualityMetricConfig:
         Identifiers of resources required to compute the quality metric.
     """
 
-    enabled: bool = True
+    enabled: bool = False
     params: dict = field(default_factory=dict)
     required_resources: list[str] = field(default_factory=list)
 
@@ -150,7 +150,7 @@ def parse_metrics_config(
         if not isinstance(cfg, Mapping):
             raise TypeError(f"Metric configuration '{name}' must be a mapping.")
 
-        enabled = cfg.get("enabled", True)
+        enabled = cfg.get("enabled", False)
 
         if not isinstance(enabled, bool):
             raise TypeError(f"Metric `enabled` flag for '{name}' must be boolean.")
@@ -216,7 +216,7 @@ def parse_rejection_policy_config(
                 f"Rejection policy configuration '{metric_name}' must be a mapping."
             )
 
-        enabled = cfg.get("enabled", True)
+        enabled = cfg.get("enabled", False)
 
         if not isinstance(enabled, bool):
             raise TypeError(

--- a/src/wf_psf/quality_control/config.py
+++ b/src/wf_psf/quality_control/config.py
@@ -231,7 +231,13 @@ def parse_rejection_policy_config(
             policies[metric_name] = RejectionPolicyConfig(enabled=False)
             continue
 
-        policy = cfg.get("policy", {})
+        if "policy" not in cfg:
+            raise ValueError(
+                f"Rejection policy configuration for '{metric_name}' "
+                "must specify a `policy`."
+            )
+
+        policy = cfg["policy"]
 
         if not isinstance(policy, Mapping):
             raise TypeError(

--- a/src/wf_psf/tests/test_quality_control/config_test.py
+++ b/src/wf_psf/tests/test_quality_control/config_test.py
@@ -136,15 +136,17 @@ def test_rejection_policy_configuration_metric_must_be_mapping():
         parse_rejection_policy_config({"goodness_of_fit": 0.25})
 
 
-def test_rejection_policy_enabled_must_be_boolean():
-    with pytest.raises(
-        TypeError,
-        match="enabled.*must be boolean",
-    ):
-        parse_rejection_policy_config({"goodness_of_fit": {"enabled": "yes"}})
-
-
-def test_rejection_policy_must_specify_one_policy():
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {},
+        {
+            "threshold": {"value": 0.25},
+            "quantile": {"value": 0.95},
+        },
+    ],
+)
+def test_rejection_policy_must_specify_exactly_one_policy(policy):
     with pytest.raises(
         ValueError,
         match="must specify exactly one policy type",
@@ -153,10 +155,22 @@ def test_rejection_policy_must_specify_one_policy():
             {
                 "goodness_of_fit": {
                     "enabled": True,
-                    "policy": {
-                        "threshold": {"value": 0.25},
-                        "quantile": {"value": 0.95},
-                    },
+                    "policy": policy,
+                }
+            }
+        )
+
+
+def test_rejection_policy_zero_policy():
+    with pytest.raises(
+        ValueError,
+        match="must specify exactly one policy type",
+    ):
+        parse_rejection_policy_config(
+            {
+                "goodness_of_fit": {
+                    "enabled": True,
+                    "policy": {},
                 }
             }
         )

--- a/src/wf_psf/tests/test_quality_control/config_test.py
+++ b/src/wf_psf/tests/test_quality_control/config_test.py
@@ -19,6 +19,7 @@ from wf_psf.quality_control.config import (
 )
 from wf_psf.quality_control.config import (
     parse_resources_config,
+    parse_rejection_policy_config,
     validate_metric_resources,
     validate_rejection_policy_metrics,
 )
@@ -56,12 +57,17 @@ def test_quality_control_config_loading():
     )
 
     assert isinstance(config.rejection["mask_obscuration"], RejectionPolicyConfig)
-    assert config.rejection["mask_obscuration"].threshold == 0.25
+    assert config.rejection["mask_obscuration"].policy == {
+        "threshold": {
+            "value": 3.0,
+        },
+    }
 
     assert isinstance(config.reporting, ReportingConfig)
     assert config.reporting.save_metrics is True
 
 
+## Tests for parsing resource configurations
 def test_parse_resources_config():
     config = {
         "psf_models": {"standard": {"inference_config": "inference_standard.yaml"}}
@@ -90,6 +96,7 @@ def test_required_resources_element_must_be_a_str():
         load_config("invalid/metric_required_resources_invalid_element.yaml")
 
 
+## Tests for parsing metrics configurations
 def test_metrics_minimal():
     config = load_config("valid/metric_minimal.yaml")
 
@@ -103,7 +110,7 @@ def test_metrics_minimal():
 def test_metric_enabled_must_be_boolean():
     with pytest.raises(
         TypeError,
-        match="Metric enabled flag for 'mask_obscuration' must be boolean",
+        match="Metric `enabled` flag for 'mask_obscuration' must be boolean",
     ):
         load_config("invalid/metric_invalid_enabled.yaml")
 
@@ -113,6 +120,7 @@ def test_metrics_configuration_must_be_mapping():
         load_config("invalid/metric_invalid_type.yaml")
 
 
+## Tests for parsing rejection policy configurations
 def test_rejection_configuration_must_be_mapping():
     with pytest.raises(
         TypeError, match="Rejection policy configuration must be a mapping"
@@ -120,6 +128,70 @@ def test_rejection_configuration_must_be_mapping():
         load_config("invalid/rejection_invalid_type.yaml")
 
 
+def test_rejection_policy_configuration_metric_must_be_mapping():
+    with pytest.raises(
+        TypeError,
+        match="Rejection policy configuration 'goodness_of_fit' must be a mapping",
+    ):
+        parse_rejection_policy_config({"goodness_of_fit": 0.25})
+
+
+def test_rejection_policy_enabled_must_be_boolean():
+    with pytest.raises(
+        TypeError,
+        match="enabled.*must be boolean",
+    ):
+        parse_rejection_policy_config({"goodness_of_fit": {"enabled": "yes"}})
+
+
+def test_rejection_policy_must_specify_one_policy():
+    with pytest.raises(
+        ValueError,
+        match="must specify exactly one policy type",
+    ):
+        parse_rejection_policy_config(
+            {
+                "goodness_of_fit": {
+                    "policy": {
+                        "threshold": {"value": 0.25},
+                        "quantile": {"value": 0.95},
+                    }
+                }
+            }
+        )
+
+
+def test_disabled_rejection_policy_does_not_require_policy():
+    result = parse_rejection_policy_config({"goodness_of_fit": {"enabled": False}})
+
+    assert result == {"goodness_of_fit": RejectionPolicyConfig(enabled=False)}
+
+
+def test_rejection_policy_configuration():
+    result = parse_rejection_policy_config(
+        {
+            "goodness_of_fit": {
+                "enabled": True,
+                "policy": {
+                    "threshold": {
+                        "value": 0.25,
+                    }
+                },
+            }
+        }
+    )
+
+    assert result["goodness_of_fit"] == RejectionPolicyConfig(
+        enabled=True,
+        policy={
+            "threshold": {
+                "value": 0.25,
+            }
+        },
+    )
+
+
+## Tests for parsing reporting configurations
 def test_reporting_configuration_must_be_mapping():
     with pytest.raises(
         TypeError,

--- a/src/wf_psf/tests/test_quality_control/config_test.py
+++ b/src/wf_psf/tests/test_quality_control/config_test.py
@@ -136,6 +136,35 @@ def test_rejection_policy_configuration_metric_must_be_mapping():
         parse_rejection_policy_config({"goodness_of_fit": 0.25})
 
 
+def test_rejection_policy_must_specify_policy():
+    with pytest.raises(
+        ValueError,
+        match="must specify a `policy`",
+    ):
+        parse_rejection_policy_config(
+            {
+                "goodness_of_fit": {
+                    "enabled": True,
+                }
+            }
+        )
+
+
+def test_rejection_policy_must_be_mapping():
+    with pytest.raises(
+        TypeError,
+        match="Rejection policy `policy` field for 'goodness_of_fit' must be a mapping",
+    ):
+        parse_rejection_policy_config(
+            {
+                "goodness_of_fit": {
+                    "enabled": True,
+                    "policy": "threshold",
+                }
+            }
+        )
+
+
 @pytest.mark.parametrize(
     "policy",
     [
@@ -156,21 +185,6 @@ def test_rejection_policy_must_specify_exactly_one_policy(policy):
                 "goodness_of_fit": {
                     "enabled": True,
                     "policy": policy,
-                }
-            }
-        )
-
-
-def test_rejection_policy_zero_policy():
-    with pytest.raises(
-        ValueError,
-        match="must specify exactly one policy type",
-    ):
-        parse_rejection_policy_config(
-            {
-                "goodness_of_fit": {
-                    "enabled": True,
-                    "policy": {},
                 }
             }
         )

--- a/src/wf_psf/tests/test_quality_control/config_test.py
+++ b/src/wf_psf/tests/test_quality_control/config_test.py
@@ -152,10 +152,11 @@ def test_rejection_policy_must_specify_one_policy():
         parse_rejection_policy_config(
             {
                 "goodness_of_fit": {
+                    "enabled": True,
                     "policy": {
                         "threshold": {"value": 0.25},
                         "quantile": {"value": 0.95},
-                    }
+                    },
                 }
             }
         )

--- a/src/wf_psf/tests/test_quality_control/conftest.py
+++ b/src/wf_psf/tests/test_quality_control/conftest.py
@@ -37,7 +37,11 @@ def qc_config_factory():
         rejection_default = {
             rejection_metric or "goodness_of_fit": RejectionPolicyConfig(
                 enabled=True,
-                threshold=0.25,
+                policy={
+                    "threshold": {
+                        "value": 0.25,
+                    },
+                },
             )
         }
 

--- a/src/wf_psf/tests/test_quality_control/data/valid/quality_control.yaml
+++ b/src/wf_psf/tests/test_quality_control/data/valid/quality_control.yaml
@@ -33,11 +33,15 @@ rejection:
 
   mask_obscuration:
     enabled: true
-    threshold: 0.25
+    policy:
+      threshold:
+        value: 3.0
 
   goodness_of_fit:
     enabled: false
-    threshold: 3.0
+    policy:
+      threshold:
+        value: 3.0
 
 reporting:
 


### PR DESCRIPTION
## Summary

This PR generalises the rejection policy configuration section by replacing the hard-coded threshold field with a generic policy mapping.  The current hard-coded representation limits the configuration model as additional policy types (e.g. quantile-based policies) may require different parameters.

Closes #247 

## What’s changed

- Replace the hard-coded threshold field with a generic policy mapping
- Update `RejectionPolicyConfig` to support policy-specific parameters
- Update `parse_rejection_policy_config()`
- Update the YAML configuration examples and fixtures
- Update rejection-policy tests
- Use backticks in error messages to highlight configuration parameter names


## How to test / verify

- Check CI tests pass.

## Scope

> Indicate the type of PR:

- [ ] Feature  
- [ ] Bug fix  
- [ ] Hotfix  
- [ ] Documentation / process change  
- [X] Internal / refactor  
- [ ] Release

> Optionally, note if this PR is part of a larger milestone or set of related PRs.


## Changelog

- [ ] Changelog fragment added (if applicable) 

No changelog fragment is added because the final user-facing configuration structure is still being developed. The changelog entry will be added with the PR that finalises the configuration structure.

## Reviewer Checklist

> Reviewers should confirm the following before approving and merging:

- [x] The PR targets the correct base branch (`develop`, or `main` for release PRs)
- [x] The PR is assigned to the developer
- [x] Appropriate labels are applied
- [x] The PR is included in relevant projects and/or milestones
- [x] Description clearly explains what has changed
- [x] Issue references included, if applicable
- [x] Code and documentation adhere to current standards (`ruff`)
- [x] Documentation updates included, if relevant
- [x] CI tests are passing
- [x] All reviewer comments have been addressed


## Next Steps / Notes (if applicable)

Continue development of the pipeline orchestration PR, incorporating the generalised rejection policy configuration into rejection policy instantiation.
